### PR TITLE
Removed GROUP BY to comply with MySQL 5.7

### DIFF
--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -134,8 +134,7 @@ class LanguagesTable extends Table {
 	 * @param array $conditions
 	 * @return array
 	 */
-	public function getList($conditions = []) {
-		$conditions += ['status' => 1];
+	public function getList($conditions = ['status' => 1]) {
 		$res = $this->find('all', ['conditions' => $conditions, 'fields' => ['id', 'name']]);
 		$ret = [];
 		foreach ($res as $language) {
@@ -150,8 +149,7 @@ class LanguagesTable extends Table {
 	 * @param array $conditions
 	 * @return array
 	 */
-	public function codeList($conditions = []) {
-		$conditions += ['status' => 1];
+	public function codeList($conditions = ['status' => 1]) {
 		$res = $this->find('all', ['conditions' => $conditions, 'fields' => ['code', 'name']]);
 		$ret = [];
 		foreach ($res as $language) {

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -134,7 +134,8 @@ class LanguagesTable extends Table {
 	 * @param array $conditions
 	 * @return array
 	 */
-	public function getList($conditions = ['status' => 1]) {
+	public function getList($conditions = []) {
+		$conditions += ['status' => 1];
 		$res = $this->find('all', ['conditions' => $conditions, 'fields' => ['id', 'name']]);
 		$ret = [];
 		foreach ($res as $language) {
@@ -149,7 +150,8 @@ class LanguagesTable extends Table {
 	 * @param array $conditions
 	 * @return array
 	 */
-	public function codeList($conditions = ['status' => 1]) {
+	public function codeList($conditions = []) {
+		$conditions += ['status' => 1];
 		$res = $this->find('all', ['conditions' => $conditions, 'fields' => ['code', 'name']]);
 		$ret = [];
 		foreach ($res as $language) {

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -135,7 +135,8 @@ class LanguagesTable extends Table {
 	 * @return array
 	 */
 	public function getList($conditions = []) {
-		$res = $this->find('all', ['group' => ['code'], 'conditions' => $conditions, 'fields' => ['id', 'name']]);
+		$conditions += ['status' => 1];
+		$res = $this->find('all', ['conditions' => $conditions, 'fields' => ['id', 'name']]);
 		$ret = [];
 		foreach ($res as $language) {
 			$ret[$language['id']] = $language['name'];
@@ -150,7 +151,8 @@ class LanguagesTable extends Table {
 	 * @return array
 	 */
 	public function codeList($conditions = []) {
-		$res = $this->find('all', ['group' => ['code'], 'conditions' => $conditions, 'fields' => ['code', 'name']]);
+		$conditions += ['status' => 1];
+		$res = $this->find('all', ['conditions' => $conditions, 'fields' => ['code', 'name']]);
 		$ret = [];
 		foreach ($res as $language) {
 			$ret[$language['code']] = $language['name'];


### PR DESCRIPTION
Old queries:
$this->find('all', ['group' => ['code'], 'conditions' => $conditions, 'fields' => ['id', 'name']]);
$this->find('all', ['group' => ['code'], 'conditions' => $conditions, 'fields' => ['code', 'name']]);

New queries:
$res = $this->find('all', ['conditions' => $conditions, 'fields' => ['id', 'name']]);
$res = $this->find('all', ['conditions' => $conditions, 'fields' => ['code', 'name']]);

Old sql:
SELECT 
  `Languages`.`id` AS `Languages__id`, 
  `Languages`.`name` AS `Languages__name` 
FROM 
  `languages` `Languages` 
GROUP BY 
  `Languages`.`code`
ORDER BY 
  `Languages`.`name` ASC

New sql:
SELECT 
  `Languages`.`id` AS `Languages__id`, 
  `Languages`.`name` AS `Languages__name` 
FROM 
  `languages` `Languages` 
WHERE 
  `status` = 1 
ORDER BY 
  `Languages`.`name` ASC


This is to fix the following MySQL Error (MySQL version 5.7):
```
Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'rims_dev_test.Languages.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```