### PR TITLE
Fix deprecated behavior method calls on table instance

### DIFF
--- a/src/Model/Table/CountriesTable.php
+++ b/src/Model/Table/CountriesTable.php
@@ -118,7 +118,9 @@ class CountriesTable extends Table {
 		}
 
 		$this->addBehavior('Search.Search');
-		$this->searchManager()
+		/** @var \Search\Model\Behavior\SearchBehavior $searchBehavior */
+		$searchBehavior = $this->getBehavior('Search');
+		$searchBehavior->searchManager()
 			->like('search', ['fields' => ['name', 'ori_name', 'iso2', 'iso3']]);
 	}
 

--- a/src/Model/Table/CurrenciesTable.php
+++ b/src/Model/Table/CurrenciesTable.php
@@ -89,7 +89,9 @@ class CurrenciesTable extends Table {
 		}
 
 		$this->addBehavior('Search.Search');
-		$this->searchManager()
+		/** @var \Search\Model\Behavior\SearchBehavior $searchBehavior */
+		$searchBehavior = $this->getBehavior('Search');
+		$searchBehavior->searchManager()
 			->like('search', ['fields' => ['name', 'code']])
 			->value('active');
 	}

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -107,7 +107,9 @@ class LanguagesTable extends Table {
 		}
 
 		$this->addBehavior('Search.Search');
-		$this->searchManager()
+		/** @var \Search\Model\Behavior\SearchBehavior $searchBehavior */
+		$searchBehavior = $this->getBehavior('Search');
+		$searchBehavior->searchManager()
 			->value('dir', ['fields' => 'direction'])
 			->like('search', ['fields' => ['name', 'ori_name', 'code', 'locale', 'locale_fallback']]);
 	}

--- a/src/Model/Table/PostalCodesTable.php
+++ b/src/Model/Table/PostalCodesTable.php
@@ -81,7 +81,9 @@ class PostalCodesTable extends Table {
 		}
 
 		$this->addBehavior('Search.Search');
-		$this->searchManager()
+		/** @var \Search\Model\Behavior\SearchBehavior $searchBehavior */
+		$searchBehavior = $this->getBehavior('Search');
+		$searchBehavior->searchManager()
 			->like('code', ['before' => false, 'after' => false])
 			->value('country');
 	}

--- a/src/Model/Table/StatesTable.php
+++ b/src/Model/Table/StatesTable.php
@@ -89,7 +89,9 @@ class StatesTable extends Table {
 		}
 
 		$this->addBehavior('Search.Search');
-		$this->searchManager()
+		/** @var \Search\Model\Behavior\SearchBehavior $searchBehavior */
+		$searchBehavior = $this->getBehavior('Search');
+		$searchBehavior->searchManager()
 			->value('country_id')
 			->like('search', ['fields' => ['name', 'code']]);
 	}

--- a/src/Model/Table/TimezonesTable.php
+++ b/src/Model/Table/TimezonesTable.php
@@ -67,7 +67,9 @@ class TimezonesTable extends Table {
 		}
 
 		$this->addBehavior('Search.Search');
-		$this->searchManager()
+		/** @var \Search\Model\Behavior\SearchBehavior $searchBehavior */
+		$searchBehavior = $this->getBehavior('Search');
+		$searchBehavior->searchManager()
 			->value('linked_id')
 			->value('type')
 			->value('active')


### PR DESCRIPTION
## Summary
- Replace `$this->searchManager()` with `$this->getBehavior('Search')->searchManager()` in 6 table classes

CakePHP 5.3 deprecates calling behavior methods directly on the table instance. The correct approach is to get the behavior instance first via `getBehavior()`.

**Affected files:**
- CountriesTable
- CurrenciesTable
- LanguagesTable
- PostalCodesTable
- StatesTable
- TimezonesTable

requires 5.2.10 patch release