### PR TITLE
Bump minimum cakephp-tools to 3.9.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"php": ">=8.2",
 		"cakephp/cakephp": "^5.1.1",
 		"dereuromark/cakephp-shim": "^3.1.0",
-		"dereuromark/cakephp-tools": "^3.0.0"
+		"dereuromark/cakephp-tools": "^3.9.2"
 	},
 	"require-dev": {
 		"cakephp/migrations": "^5.0.0",


### PR DESCRIPTION
## Summary
- Bumps minimum `dereuromark/cakephp-tools` from `^3.0.0` to `^3.9.2`
- Fixes `prefer-lowest` CI failure caused by `Tools\Utility\Mime` class using undefined `_mimeTypes` property in older versions
- The `Mime` class was refactored in tools 3.9.2 to properly initialize mime type data instead of relying on inherited `Response` properties that were removed in newer CakePHP versions