### PR TITLE
Increase PHPStan level from 7 to 8

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 7
+	level: 8
 	paths:
 		- src/
 	bootstrapFiles:

--- a/src/Controller/Admin/AddressesController.php
+++ b/src/Controller/Admin/AddressesController.php
@@ -83,7 +83,8 @@ class AddressesController extends DataAppController {
 		}
 		if (!$this->request->getData()) {
 			$belongsTo = ['' => ' - keine Auswahl - '];
-			foreach ($this->Addresses->belongsTo as $b => $content) {
+			$associations = $this->Addresses->belongsTo ?? [];
+			foreach ($associations as $b => $content) {
 				if ($b === 'Country') {
 					continue;
 				}
@@ -123,12 +124,14 @@ class AddressesController extends DataAppController {
 	/**
 	 * @param int|null $id
 	 *
-	 * @return \Cake\Http\Response
+	 * @return \Cake\Http\Response|null
 	 */
 	public function markAsUsed($id = null) {
 		$address = $this->Addresses->get($id);
 
-		$this->Addresses->touch($id);
+		/** @var int $addressId */
+		$addressId = $address->id;
+		$this->Addresses->touch($addressId);
 		$var = $address['formatted_address'];
 		$this->Flash->success(__('Address \'{0}\' marked as last used', h($var)));
 

--- a/src/Controller/Admin/CurrenciesController.php
+++ b/src/Controller/Admin/CurrenciesController.php
@@ -35,7 +35,7 @@ class CurrenciesController extends DataAppController {
 	}
 
 	/**
-	 * @return \Cake\Http\Response
+	 * @return \Cake\Http\Response|null
 	 */
 	public function update() {
 		$this->Currencies->updateValues();
@@ -158,7 +158,7 @@ class CurrenciesController extends DataAppController {
 	/**
 	 * @param int|null $id
 	 *
-	 * @return \Cake\Http\Response
+	 * @return \Cake\Http\Response|null
 	 */
 	public function _setAsPrimary($id) {
 		if ($id) {

--- a/src/Controller/Admin/LanguagesController.php
+++ b/src/Controller/Admin/LanguagesController.php
@@ -138,7 +138,7 @@ class LanguagesController extends DataAppController {
 		}
 
 		//$languages = $this->Languages->iso3ToIso2();
-		$languages = $this->Languages->catalog();
+		$languages = $this->Languages->catalog() ?? [];
 		$count = 0;
 		$errors = [];
 		foreach ($languages as $language) {
@@ -191,7 +191,7 @@ class LanguagesController extends DataAppController {
 	public function compareIsoListToCore() {
 		$isoList = $this->Languages->getOfficialIsoList();
 
-		$languages = $this->Languages->catalog();
+		$languages = $this->Languages->catalog() ?? [];
 		$locales = [];
 		foreach ($languages as $key => $value) {
 			if (strlen($key) === 2) {

--- a/src/Controller/Admin/MimeTypeImagesController.php
+++ b/src/Controller/Admin/MimeTypeImagesController.php
@@ -249,9 +249,9 @@ class MimeTypeImagesController extends DataAppController {
 	}
 
 	/**
-	 * @var string|null
+	 * @var string
 	 */
-	protected $_uploadError;
+	protected string $_uploadError = '';
 
 	/**
 	 * @var array
@@ -274,6 +274,12 @@ class MimeTypeImagesController extends DataAppController {
 			'gif',
 			'png',
 		];
+
+		if (!$file || !isset($file['name'], $file['tmp_name'])) {
+			$this->_uploadError = 'No file uploaded';
+
+			return false;
+		}
 
 		$image = $file['name'];
 		$ext = mb_strtolower(pathinfo($image, PATHINFO_EXTENSION));
@@ -406,7 +412,7 @@ class MimeTypeImagesController extends DataAppController {
 	/**
 	 * @param int|null $id
 	 *
-	 * @return \Cake\Http\Response
+	 * @return \Cake\Http\Response|null
 	 */
 	public function delete($id = null) {
 		$this->request->allowMethod('post');

--- a/src/Controller/Admin/MimeTypesController.php
+++ b/src/Controller/Admin/MimeTypesController.php
@@ -269,7 +269,7 @@ class MimeTypesController extends DataAppController {
 	/**
 	 * @param int|null $id
 	 *
-	 * @return \Cake\Http\Response
+	 * @return \Cake\Http\Response|null
 	 */
 	public function delete($id = null) {
 		$this->request->allowMethod('post');

--- a/src/Controller/Admin/StatesController.php
+++ b/src/Controller/Admin/StatesController.php
@@ -64,7 +64,7 @@ class StatesController extends DataAppController {
 		//$this->request->allowMethod('ajax');
 
 		$this->viewBuilder()->setLayout('ajax');
-		$states = $this->States->getListByCountry($id);
+		$states = $this->States->getListByCountry((int)$id);
 		$defaultFieldLabel = 'pleaseSelect';
 		if ($this->request->getQuery('optional')) {
 			$defaultFieldLabel = 'doesNotMatter';

--- a/src/Controller/StatesController.php
+++ b/src/Controller/StatesController.php
@@ -61,7 +61,7 @@ class StatesController extends DataAppController {
 	 */
 	public function updateSelect($id = null) {
 		$this->viewBuilder()->setLayout('ajax');
-		$states = $this->States->getListByCountry($id);
+		$states = $this->States->getListByCountry((int)$id);
 
 		$defaultFieldLabel = 'pleaseSelect';
 		if ($this->request->getQuery('optional')) {

--- a/src/Currency/CurrencyBitcoinLib.php
+++ b/src/Currency/CurrencyBitcoinLib.php
@@ -45,6 +45,9 @@ class CurrencyBitcoinLib {
 		curl_close($ch);
 		*/
 		$response = $this->_get($url);
+		if ($response === null) {
+			return null;
+		}
 
 		$data = json_decode($response, true);
 

--- a/src/Currency/CurrencyLib.php
+++ b/src/Currency/CurrencyLib.php
@@ -254,6 +254,9 @@ class CurrencyLib {
 	protected function _getBitcoin() {
 		$Btc = new CurrencyBitcoinLib(['currency' => $this->baseCurrency]);
 		$current = $Btc->coingecko();
+		if ($current === null) {
+			return 0.0;
+		}
 
 		return $Btc->ratio($current);
 	}

--- a/src/Model/Entity/Address.php
+++ b/src/Model/Entity/Address.php
@@ -45,7 +45,7 @@ class Address extends Entity {
 
 	/**
 	 * @param int|null $value
-	 * @return array|string
+	 * @return array<int|string, mixed>|string|null
 	 */
 	public static function addressTypes($value = null) {
 		$options = [

--- a/src/Model/Entity/Continent.php
+++ b/src/Model/Entity/Continent.php
@@ -36,7 +36,7 @@ class Continent extends Entity {
 
 	/**
 	 * @param array<int>|int|null $value
-	 * @return array<string>|string
+	 * @return array<int|string, mixed>|string|null
 	 */
 	public static function directions($value = null) {
 		$options = [

--- a/src/Model/Table/CurrenciesTable.php
+++ b/src/Model/Table/CurrenciesTable.php
@@ -182,6 +182,9 @@ class CurrenciesTable extends Table {
 		$this->CurrencyLib->reset();
 
 		$base = $this->baseCurrency();
+		if (!$base) {
+			return;
+		}
 		$currencies = $this->foreignCurrencies()->all();
 		foreach ($currencies as $currency) {
 			$value = $this->CurrencyLib->convert(1, $base['code'], $currency['code'], 4);
@@ -246,6 +249,9 @@ class CurrenciesTable extends Table {
 	 */
 	public function currencyList() {
 		$res = $this->availableCurrencies();
+		if (!isset($this->CurrencyLib)) {
+			$this->CurrencyLib = new CurrencyLib();
+		}
 		foreach ($res as $key => $val) {
 			$val = $key;
 

--- a/src/Model/Table/LocationsTable.php
+++ b/src/Model/Table/LocationsTable.php
@@ -131,7 +131,7 @@ class LocationsTable extends Table {
 	}
 
 	/**
-	 * @return \Cake\ORM\Query\SelectQuery|false
+	 * @return \Cake\ORM\Query\SelectQuery|false|null
 	 */
 	public function findLocationByIp() {
 		$ip = static::findIp();

--- a/src/Model/Table/TimezonesTable.php
+++ b/src/Model/Table/TimezonesTable.php
@@ -149,11 +149,12 @@ class TimezonesTable extends Table {
 			$allTimezones = Hash::combine($allTimezones, '{n}.name', '{n}');
 		}
 
-		if (strpos($timezone->notes, 'Link to [[') === false) {
+		$notes = $timezone->notes ?? '';
+		if (strpos($notes, 'Link to [[') === false) {
 			return null;
 		}
 
-		preg_match('/Link to \[\[(.+?)\]\]/', $timezone->notes, $matches);
+		preg_match('/Link to \[\[(.+?)\]\]/', $notes, $matches);
 		if (!$matches) {
 			return null;
 		}

--- a/src/View/Helper/MimeTypeHelper.php
+++ b/src/View/Helper/MimeTypeHelper.php
@@ -42,8 +42,9 @@ class MimeTypeHelper extends Helper {
 		}
 
 		$default = ['ext' => $ext, 'name' => 'Datei'];
+		$types = $this->types ?? [];
 
-		foreach ($this->types as $t) {
+		foreach ($types as $t) {
 			if ($t['ext'] == $ext) {
 				if (!empty($t['img'])) {
 					return $this->formatIcon($t, $attr);
@@ -61,17 +62,19 @@ class MimeTypeHelper extends Helper {
 	}
 
 	/**
-	 * @param array|null $icon
+	 * @param array<string, mixed> $icon
 	 * @param array<string, mixed> $attr
 	 * @return string
 	 */
-	public function formatIcon($icon = null, array $attr = []) {
+	public function formatIcon(array $icon, array $attr = []) {
 		$filename = '*';
 		if (!empty($attr['filename'])) {
 			$filename = $attr['filename'];
 			unset($attr['filename']);
 		}
-		$imageAttr = ['class' => 'help', 'title' => $icon['name'] . ' (' . $filename . '.' . $icon['ext'] . ')', 'alt' => $icon['ext'], 'height' => '16'];
+		$name = $icon['name'] ?? '';
+		$ext = $icon['ext'] ?? '';
+		$imageAttr = ['class' => 'help', 'title' => $name . ' (' . $filename . '.' . $ext . ')', 'alt' => $ext, 'height' => '16'];
 		if ($attr) {
 			$imageAttr = array_merge($imageAttr, $attr);
 		}


### PR DESCRIPTION
## Summary
- Increase PHPStan analysis level from 7 to 8
- Fix all 33 level 8 errors:
  - Add null checks for nullable properties and method returns
  - Fix return type annotations for controller actions
  - Add type hints and default values for class properties
  - Handle nullable parameters properly