### PR TITLE
Fix PHPStan error: remove redundant isset check

### DIFF
--- a/src/Sync/Timezones.php
+++ b/src/Sync/Timezones.php
@@ -289,7 +289,7 @@ class Timezones {
 	 */
 	public static function stringToInt(string $offset): int {
 		preg_match('/^([+-]?)(\d+):(\d+)$/', $offset, $matches);
-		if (!$matches || !isset($matches[1]) || empty($matches[2]) || empty($matches[3])) {
+		if (!$matches || empty($matches[2]) || empty($matches[3])) {
 			throw new InvalidArgumentException('Invalid offset');
 		}
 


### PR DESCRIPTION
Removes redundant `isset($matches[1])` check - when preg_match succeeds, offset 1 always exists.