### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Addresses/index.php
+++ b/templates/Addresses/index.php
@@ -72,7 +72,14 @@ foreach ($addresses as $address):
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $address['id']], ['escape' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $address['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $address['id']], ['escape' => false, 'confirm' => 'Sure?']); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $address['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => 'Sure?',
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -90,3 +97,4 @@ foreach ($addresses as $address):
 		<li><?php echo $this->Html->link(__('Add {0}', __('Address')), ['action' => 'add']); ?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Addresses/view.php
+++ b/templates/Addresses/view.php
@@ -80,7 +80,14 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit {0}', __('Address')), ['action' => 'edit', $address['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete {0}', __('Address')), ['action' => 'delete', $address['id']], ['confirm' => __('Are you sure you want to delete # {0}?', $address['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Address')), ['action' => 'delete', $address['id']], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $address['id']),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Addresses')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Addresses/edit.php
+++ b/templates/Admin/Addresses/edit.php
@@ -40,7 +40,14 @@ use Cake\Core\Configure;
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('Address.id')], null, __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('Address.id'))); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('Address.id')], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('Address.id')),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Addresses')), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Addresses/index.php
+++ b/templates/Admin/Addresses/index.php
@@ -88,7 +88,14 @@ foreach ($addresses as $address):
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $address['id']], ['escape' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $address['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $address['id']], ['escape' => false, 'confirm' => 'Sure?']); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $address['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => 'Sure?',
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -106,3 +113,4 @@ foreach ($addresses as $address):
 		<li><?php echo $this->Html->link(__('Add {0}', __('Address')), ['action' => 'add']); ?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Addresses/view.php
+++ b/templates/Admin/Addresses/view.php
@@ -81,7 +81,14 @@
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit {0}', __('Address')), ['action' => 'edit', $address['id']]); ?> </li>
 		<li><?php echo $this->Html->link(__('Mark as {0}', __('Used')), ['action' => 'mark_as_used', $address['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete {0}', __('Address')), ['action' => 'delete', $address['id']], ['confirm' => __('Are you sure you want to delete # {0}?', $address['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Address')), ['action' => 'delete', $address['id']], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $address['id']),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Addresses')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Cities/edit.php
+++ b/templates/Admin/Cities/edit.php
@@ -38,7 +38,14 @@ use Cake\Core\Configure;
 <div class="actions">
 	<ul>
 
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('City.id')], null, __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('City.id'))); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('City.id')], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('City.id')),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Cities')), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Cities/index.php
+++ b/templates/Admin/Cities/index.php
@@ -47,7 +47,14 @@ foreach ($cities as $city) { ?>
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $city['id']], ['escape' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $city['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $city['id']], ['escape' => false, 'confirm' => 'Sure?']); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $city['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => 'Sure?',
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php } ?>
@@ -64,3 +71,4 @@ foreach ($cities as $city) { ?>
 		<li><?php echo $this->Html->link(__('New {0}', __('City')), ['action' => 'add']); ?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Cities/view.php
+++ b/templates/Admin/Cities/view.php
@@ -66,7 +66,14 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit {0}', __('City')), ['action' => 'edit', $city['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete {0}', __('City')), ['action' => 'delete', $city['id']], ['confirm' => __('Are you sure you want to delete # {0}?', $city['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete {0}', __('City')), ['action' => 'delete', $city['id']], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $city['id']),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Cities')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Continents/edit.php
+++ b/templates/Admin/Continents/edit.php
@@ -26,7 +26,14 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('Continent.id')], ['confirm' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('Continent.id'))]); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('Continent.id')], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('Continent.id')),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Continents')), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Continents/index.php
+++ b/templates/Admin/Continents/index.php
@@ -34,7 +34,14 @@ foreach ($continents as $continent):
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $continent['id']], ['escape' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $continent['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $continent['id']], ['escape' => false, 'confirm' => 'Sure?']); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $continent['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => 'Sure?',
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -53,3 +60,4 @@ foreach ($continents as $continent):
 		<li><?php echo $this->Html->link(__('Tree'), ['action' => 'tree']); ?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Continents/view.php
+++ b/templates/Admin/Continents/view.php
@@ -44,6 +44,13 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit {0}', __('Continent')), ['action' => 'edit', $continent['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete {0}', __('Continent')), ['action' => 'delete', $continent['id']], ['confirm' => __('Are you sure you want to delete # {0}?', $continent['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Continent')), ['action' => 'delete', $continent['id']], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $continent['id']),
+			],
+		]); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Countries/edit.php
+++ b/templates/Admin/Countries/edit.php
@@ -39,7 +39,15 @@ use Cake\Core\Configure;
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $country->id], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $country->id)]); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $country->id], [
+			'escape' => false,
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $country->id),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Countries/index.php
+++ b/templates/Admin/Countries/index.php
@@ -106,7 +106,14 @@ foreach ($countries as $country):
 
 			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __('Koordinaten updaten')]), ['action' => 'update_coordinates', $country->id], ['escape' => false]); ?>
 
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $country->id], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $country->id)]); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $country->id], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $country->id),
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -129,6 +136,7 @@ Hinweis:
 <ul>
 <li><?__('countryCodeExplanation')?></li>
 </ul>
+<?= $this->element('Data.csp_confirm') ?>
 
 <br/>
 <span class="keyList">Legende:</span>

--- a/templates/Admin/Countries/view.php
+++ b/templates/Admin/Countries/view.php
@@ -67,7 +67,15 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit {0}', __('Country')), ['action' => 'edit', $country->id]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete Country'), ['action' => 'delete', $country->id], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $country->id)]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete Country'), ['action' => 'delete', $country->id], [
+			'escape' => false,
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $country->id),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Currencies/edit.php
+++ b/templates/Admin/Currencies/edit.php
@@ -22,7 +22,15 @@
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $currency->id], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $currency->id)]); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $currency->id], [
+			'escape' => false,
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $currency->id),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Currencies')), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Currencies/index.php
+++ b/templates/Admin/Currencies/index.php
@@ -65,7 +65,14 @@ foreach ($currencies as $currency):
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $currency['id']], ['escape' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $currency['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $currency['id']], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $currency['id'])]); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $currency['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $currency['id']),
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -80,3 +87,4 @@ foreach ($currencies as $currency):
 		<li><?php echo $this->Html->link(__('Update {0}', __('Currency Values')), ['action' => 'update']); ?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Currencies/view.php
+++ b/templates/Admin/Currencies/view.php
@@ -47,8 +47,16 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit {0}', __('Currency')), ['action' => 'edit', $currency['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete Currency'), ['action' => 'delete', $currency['id']], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $currency['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete Currency'), ['action' => 'delete', $currency['id']], [
+			'escape' => false,
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $currency['id']),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Currencies')), ['action' => 'index']); ?> </li>
 		<li><?php echo $this->Html->link(__('Add {0}', __('Currency')), ['action' => 'add']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Languages/edit.php
+++ b/templates/Admin/Languages/edit.php
@@ -28,7 +28,14 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $language->id], ['confirm' => __('Are you sure you want to delete # {0}?', $language->id)]); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $language->id], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $language->id),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Languages')), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Languages/index.php
+++ b/templates/Admin/Languages/index.php
@@ -76,7 +76,14 @@ foreach ($languages as $language):
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $language['id']], ['escape' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $language['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $language['id']], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $language['id'])]); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $language['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $language['id']),
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -101,3 +108,4 @@ The language flags are actually country flags. Due to incompatabities between co
 		<li><?php echo $this->Html->link(__('Set primary languages active'), ['action' => 'set_primary_languages_active'], [], __('Sure?')); ?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Languages/view.php
+++ b/templates/Admin/Languages/view.php
@@ -50,7 +50,14 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit {0}', __('Language')), ['action' => 'edit', $language['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete {0}', __('Language')), ['action' => 'delete', $language['id']], ['confirm' => __('Are you sure you want to delete # {0}?', $language['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Language')), ['action' => 'delete', $language['id']], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $language['id']),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Languages')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypeImages/edit.php
+++ b/templates/Admin/MimeTypeImages/edit.php
@@ -27,7 +27,14 @@
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('MimeTypeImages.id')], ['confirm' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('MimeTypeImage.id'))]); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('MimeTypeImages.id')], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('MimeTypeImage.id')),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List Mime Type Images'), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypeImages/index.php
+++ b/templates/Admin/MimeTypeImages/index.php
@@ -84,7 +84,14 @@ foreach ($mimeTypeImages as $mimeTypeImage):
 		<td class="actions">
 			<?php //echo $this->Html->link($this->Icon->render('view'), array('action'=>'view', $mimeTypeImage['id']), array('escape'=>false)); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $mimeTypeImage['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $mimeTypeImage['id']], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $mimeTypeImage['id'])]); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $mimeTypeImage['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $mimeTypeImage['id']),
+				],
+			]); ?>
 			<?php
 				if (isset($imageWidth) && isset($imageHeight) && $imageWidth != 16 && $imageHeight != 16) {
 					echo $this->Icon->render('expand', ['title' => __('Größe ist nicht 16x16, sondern ' . $imageWidth . 'x' . $imageHeight . '! Anpassen...')]);
@@ -106,3 +113,4 @@ foreach ($mimeTypeImages as $mimeTypeImage):
 		<li><?php echo $this->Html->link(__('Search Icon on google.de'), 'http://images.google.de/images?q=icon+imagesize%3A16x16&btnG=Bilder-Suche'); ?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypeImages/view.php
+++ b/templates/Admin/MimeTypeImages/view.php
@@ -37,8 +37,16 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit Mime Type Image'), ['action' => 'edit', $mimeTypeImage['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete Mime Type Image'), ['action' => 'delete', $mimeTypeImage['id']], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $mimeTypeImage['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete Mime Type Image'), ['action' => 'delete', $mimeTypeImage['id']], [
+			'escape' => false,
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $mimeTypeImage['id']),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List Mime Type Images'), ['action' => 'index']); ?> </li>
 		<li><?php echo $this->Html->link(__('Add Mime Type Image'), ['action' => 'add']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypes/add.php
+++ b/templates/Admin/MimeTypes/add.php
@@ -4,12 +4,13 @@
  * @var array $mimeTypeImages
  * @var \Data\Model\Entity\MimeType $mimeType
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <?php /**
  * @var \App\View\AppView $this
  */
 $this->Html->script('jquery/plugins/jquery.dd.js');?>
-<script type="text/javascript">
+<script type="text/javascript"<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 	var imagePath = baseurl + 'img/<?php echo IMG_MIMETYPES?>';
 </script>
 <?php echo $this->Html->script('specific/mime_types_images.js');?>

--- a/templates/Admin/MimeTypes/edit.php
+++ b/templates/Admin/MimeTypes/edit.php
@@ -3,12 +3,13 @@
  * @var \App\View\AppView $this
  * @var \Data\Model\Entity\MimeType $mimeType
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <?php /**
  * @var \App\View\AppView $this
  */
 $this->Html->script('jquery/plugins/jquery.dd.js');?>
-<script type="text/javascript">
+<script type="text/javascript"<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 	var imagePath = baseurl + 'img/<?php echo IMG_MIMETYPES?>';
 </script>
 <?php echo $this->Html->script('specific/mime_types_images.js');?>
@@ -36,7 +37,14 @@ $this->Html->script('jquery/plugins/jquery.dd.js');?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('MimeType.id')], ['confirm' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('MimeType.id'))]); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('MimeType.id')], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('MimeType.id')),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypes/index.php
+++ b/templates/Admin/MimeTypes/index.php
@@ -96,7 +96,14 @@ foreach ($mimeTypes as $mimeType):
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $mimeType['id']], ['escape' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $mimeType['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $mimeType['id']], ['escape' => false, 'confirm'  => __('Are you sure you want to delete # {0}?', $mimeType['id'])]); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $mimeType['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $mimeType['id']),
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -128,3 +135,4 @@ message = für Nachrichten<br/>
 model = für Dateien, die mehrdimensionale Strukturen repräsentieren<br/>
 <br/>
 Subtypen für server-eigene Dateiformate, d.h. Dateitypen, die auf dem Server ausgeführt werden können, werden meist mit x- eingeleitet.
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypes/view.php
+++ b/templates/Admin/MimeTypes/view.php
@@ -37,8 +37,16 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit Mime Type'), ['action' => 'edit', $mimeType['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete Mime Type'), ['action' => 'delete', $mimeType['id']], ['escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $mimeType['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete Mime Type'), ['action' => 'delete', $mimeType['id']], [
+			'escape' => false,
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $mimeType['id']),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']); ?> </li>
 		<li><?php echo $this->Html->link(__('Add Mime Type'), ['action' => 'add']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/PostalCodes/edit.php
+++ b/templates/Admin/PostalCodes/edit.php
@@ -25,7 +25,14 @@
 <div class="actions">
 	<ul>
 
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('PostalCode.id')], ['confirm' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('PostalCode.id'))]); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('PostalCode.id')], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('PostalCode.id')),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Postal Codes')), ['action' => 'index']);?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/PostalCodes/index.php
+++ b/templates/Admin/PostalCodes/index.php
@@ -57,7 +57,14 @@ foreach ($postalCodes as $postalCode): ?>
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $postalCode['id']], ['escape' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $postalCode['id']], ['escape' => false]); ?>
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $postalCode['id']], ['escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $postalCode['id'])]); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $postalCode['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $postalCode['id']),
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -76,3 +83,4 @@ foreach ($postalCodes as $postalCode): ?>
 		<li><?php echo $this->Html->link(__('Geolocate'), ['action' => 'geolocate']); ?></li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/PostalCodes/view.php
+++ b/templates/Admin/PostalCodes/view.php
@@ -56,7 +56,14 @@
 <div class="actions">
 	<ul>
 		<li><?php echo $this->Html->link(__('Edit {0}', __('Postal Code')), ['action' => 'edit', $postalCode['id']]); ?> </li>
-		<li><?php echo $this->Form->postLink(__('Delete {0}', __('Postal Code')), ['action' => 'delete', $postalCode['id']], ['confirm' => __('Are you sure you want to delete # {0}?', $postalCode['id'])]); ?> </li>
+		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Postal Code')), ['action' => 'delete', $postalCode['id']], [
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $postalCode['id']),
+			],
+		]); ?> </li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Postal Codes')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/States/edit.php
+++ b/templates/Admin/States/edit.php
@@ -23,8 +23,16 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postLink(__('Delete'), ['action' => 'delete', $state->id], ['escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $state->id)]); ?></li>
+		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $state->id], [
+			'escape' => false,
+			'class' => 'btn btn-link p-0 align-baseline',
+			'form' => [
+				'class' => 'd-inline',
+				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $state->id),
+			],
+		]); ?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('States')), ['action' => 'index']);?></li>
 		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['controller' => 'countries', 'action' => 'index']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/States/index.php
+++ b/templates/Admin/States/index.php
@@ -86,7 +86,14 @@ foreach ($states as $state):
 
 			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __('Update coordinates')]), ['action' => 'updateCoordinates', $state['id']], ['escape' => false]); ?>
 
-			<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $state['id']], ['escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $state['id'])]); ?>
+			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $state['id']], [
+				'escape' => false,
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $state['id']),
+				],
+			]); ?>
 		</td>
 	</tr>
 <?php endforeach; ?>
@@ -104,3 +111,4 @@ foreach ($states as $state):
 		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['controller' => 'Countries', 'action' => 'index']); ?> </li>
 	</ul>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Timezones/edit.php
+++ b/templates/Admin/Timezones/edit.php
@@ -8,10 +8,16 @@
     <aside class="column large-3 medium-4 columns col-sm-4 col-12">
         <ul class="side-nav nav nav-pills flex-column">
             <li class="nav-item heading"><?= __('Actions') ?></li>
-            <li class="nav-item"><?= $this->Form->postLink(
+            <li class="nav-item"><?= $this->Form->postButton(
                 __('Delete'),
                 ['action' => 'delete', $timezone->id],
-                ['confirm' => __('Are you sure you want to delete # {0}?', $timezone->id), 'class' => 'side-nav-item']
+                [
+                    'class' => 'side-nav-item btn btn-link text-start w-100',
+                    'form' => [
+                        'class' => 'd-inline',
+                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $timezone->id),
+                    ],
+                ]
                 ) ?></li>
             <li class="nav-item"><?= $this->Html->link(__('List Timezones'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
@@ -41,3 +47,4 @@
         </div>
     </div>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Timezones/index.php
+++ b/templates/Admin/Timezones/index.php
@@ -82,7 +82,14 @@ use Cake\Core\Plugin;
                     <td class="actions">
                         <?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $timezone->id], ['escapeTitle' => false]); ?>
                         <?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $timezone->id], ['escapeTitle' => false]); ?>
-                        <?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $timezone->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $timezone->id)]); ?>
+                        <?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $timezone->id], [
+                            'escapeTitle' => false,
+                            'class' => 'btn btn-link p-0 align-baseline',
+                            'form' => [
+                                'class' => 'd-inline',
+                                'data-confirm-message' => __('Are you sure you want to delete # {0}?', $timezone->id),
+                            ],
+                        ]); ?>
                     </td>
                 </tr>
                 <?php endforeach; ?>
@@ -92,3 +99,4 @@ use Cake\Core\Plugin;
 
     <?php echo $this->element('Tools.pagination'); ?>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Timezones/view.php
+++ b/templates/Admin/Timezones/view.php
@@ -9,7 +9,13 @@
         <ul class="side-nav nav nav-pills flex-column">
             <li class="nav-item heading"><?= __('Actions') ?></li>
             <li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('Timezone')), ['action' => 'edit', $timezone->id], ['class' => 'side-nav-item']) ?></li>
-            <li class="nav-item"><?= $this->Form->postLink(__('Delete {0}', __('Timezone')), ['action' => 'delete', $timezone->id], ['confirm' => __('Are you sure you want to delete # {0}?', $timezone->id), 'class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Form->postButton(__('Delete {0}', __('Timezone')), ['action' => 'delete', $timezone->id], [
+                'class' => 'side-nav-item btn btn-link text-start w-100',
+                'form' => [
+                    'class' => 'd-inline',
+                    'data-confirm-message' => __('Are you sure you want to delete # {0}?', $timezone->id),
+                ],
+            ]) ?></li>
             <li class="nav-item"><?= $this->Html->link(__('List {0}', __('Timezones')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
     </aside>
@@ -79,3 +85,4 @@
         </div>
     </div>
 </div>
+<?= $this->element('Data.csp_confirm') ?>

--- a/templates/element/csp_confirm.php
+++ b/templates/element/csp_confirm.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * CSP-safe confirmation delegate for Form->postButton() forms.
+ *
+ * Attaches a single submit listener to every <form data-confirm-message="...">
+ * on the page and shows a native confirm() dialog before submission. This
+ * replaces the inline onclick handler that Form->postLink() + ['confirm' => ...]
+ * would emit, which is blocked under a strict CSP.
+ *
+ * Include once at the bottom of any template that renders a postButton:
+ *   <?= $this->element('Data.csp_confirm') ?>
+ *
+ * Falls back gracefully: when the host app does not set a cspNonce request
+ * attribute, the nonce= attribute is not rendered at all.
+ *
+ * @var \Cake\View\View $this
+ */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
+?>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+	form.addEventListener('submit', function(e) {
+		if (!confirm(this.dataset.confirmMessage)) {
+			e.preventDefault();
+		}
+	});
+});
+</script>


### PR DESCRIPTION
## Summary

- Add a reusable `templates/element/csp_confirm.php` element that emits a nonce-aware `<script>` block with a `form[data-confirm-message]` submit delegate. Templates opt in via `<?= $this->element('Data.csp_confirm') ?>`.
- Replace 34 `Form->postLink` + `confirm` calls with `Form->postButton` + `data-confirm-message` across all admin templates and the user-facing `Addresses` CRUD pages.
- Add nonce to 2 inline `<script>` blocks in `Admin/MimeTypes/add.php` and `Admin/MimeTypes/edit.php` (the `imagePath` assignment).

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- **New element `templates/element/csp_confirm.php`**: centralizes the delegate so every migrated template can include it with a single line and pick up new improvements automatically. Falls back gracefully when no `cspNonce` request attribute is set.
- **34 postLink migrations**: all admin CRUD `view.php` / `edit.php` / `index.php` templates across `States`, `Languages`, `Countries`, `Currencies`, `Cities`, `Addresses`, `Timezones`, `PostalCodes`, `Continents`, `MimeTypes`, `MimeTypeImages`, plus the user-facing `Addresses/view.php` and `Addresses/index.php`.
- **MimeTypes inline scripts**: add `nonce` to the 2 `<script type="text/javascript">` blocks that set `imagePath`.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $country->id], [
-     'escape' => false,
-     'confirm' => __('Are you sure you want to delete # {0}?', $country->id),
- ]) ?>
+ <?= $this->Form->postButton(__('Delete'), ['action' => 'delete', $country->id], [
+     'escape' => false,
+     'class' => 'btn btn-link p-0 align-baseline',
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => __('Are you sure you want to delete # {0}?', $country->id),
+     ],
+ ]) ?>
...
+ <?= $this->element('Data.csp_confirm') ?>
```

Note: the postButton renders as `<form><button>` rather than `<a>`, so the visual rendering in action-cell table rows is slightly different. I kept the link-looking button via `btn btn-link p-0 align-baseline`. In sidebar action lists (`side-nav-item`) the class is `side-nav-item btn btn-link text-start w-100` so the form fills the row.
