### PR TITLE
Use escapeTitle for HTML-titled Html->link() calls

### DIFF
--- a/templates/Addresses/index.php
+++ b/templates/Addresses/index.php
@@ -70,8 +70,8 @@ foreach ($addresses as $address):
 			<?php echo h($address['formatted_address']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $address['id']], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $address['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $address['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $address['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $address['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',

--- a/templates/Admin/Addresses/index.php
+++ b/templates/Admin/Addresses/index.php
@@ -69,12 +69,12 @@ foreach ($addresses as $address):
 
 					if (Configure::read('GoogleMap.key')) {
 						$mapMarkers = $this->GoogleMap->staticMarkers($markers);
-						echo $this->Html->link($this->Icon->render('view', ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $address->lat . ',' . $address->lng, 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 12]), ['id' => 'googleMap', 'class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escape' => false, 'target' => '_blank']);
+						echo $this->Html->link($this->Icon->render('view', ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $address->lat . ',' . $address->lng, 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 12]), ['id' => 'googleMap', 'class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 					} else {
 						$options = [
 							'to' => $address->lat . ',' . $address->lng,
 						];
-						echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escape' => false, 'target' => '_blank']);
+						echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 					}
 				}
 			 ?>
@@ -86,8 +86,8 @@ foreach ($addresses as $address):
 			<?php echo h($address['formatted_address']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $address['id']], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $address['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $address['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $address['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $address['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',

--- a/templates/Admin/Cities/index.php
+++ b/templates/Admin/Cities/index.php
@@ -45,8 +45,8 @@ foreach ($cities as $city) { ?>
 			<?php echo $this->Time->niceDate($city['modified']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $city['id']], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $city['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $city['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $city['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $city['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',

--- a/templates/Admin/Continents/index.php
+++ b/templates/Admin/Continents/index.php
@@ -32,8 +32,8 @@ foreach ($continents as $continent):
 			<?php echo $this->Time->niceDate($continent['modified']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $continent['id']], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $continent['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $continent['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $continent['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $continent['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',

--- a/templates/Admin/Countries/index.php
+++ b/templates/Admin/Countries/index.php
@@ -80,12 +80,12 @@ foreach ($countries as $country):
 
 				if (Configure::read('GoogleMap.key')) {
 					$mapMarkers = $this->GoogleMap->staticMarkers($markers);
-					echo ' ' . $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $country['lat'] . ',' . $country['lng'], 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 3]), ['class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escape' => false, 'target' => '_blank']);
+					echo ' ' . $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $country['lat'] . ',' . $country['lng'], 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 3]), ['class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 				} else {
 					$options = [
 						'to' => $country->lat . ',' . $country->lng,
 					];
-					echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escape' => false, 'target' => '_blank']);
+					echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 				}
 			}
 
@@ -99,12 +99,12 @@ foreach ($countries as $country):
 			<?php echo $this->Time->niceDate($country['modified']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('up'), ['action' => 'up', $country->id], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('down'), ['action' => 'down', $country->id], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action'=>'view', $country->id], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $country->id], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('up'), ['action' => 'up', $country->id], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('down'), ['action' => 'down', $country->id], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action'=>'view', $country->id], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $country->id], ['escapeTitle' => false]); ?>
 
-			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __('Koordinaten updaten')]), ['action' => 'update_coordinates', $country->id], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __('Koordinaten updaten')]), ['action' => 'update_coordinates', $country->id], ['escapeTitle' => false]); ?>
 
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $country->id], [
 				'escapeTitle' => false,

--- a/templates/Admin/Currencies/index.php
+++ b/templates/Admin/Currencies/index.php
@@ -52,19 +52,19 @@ foreach ($currencies as $currency):
 		</td>
 		<td>
 			<span class="ajaxToggling" id="ajaxToggle-<?php echo $currency['id']?>">
-			<?php echo $this->Html->link($this->Format->yesNo($currency['active'], ['onTitle' => __('Active'), 'offTitle' => __('Inactive')]), ['action' => 'toggle', 'active', $currency['id']], ['escape' => false]); ?></span>&nbsp;&nbsp;<?php
+			<?php echo $this->Html->link($this->Format->yesNo($currency['active'], ['onTitle' => __('Active'), 'offTitle' => __('Inactive')]), ['action' => 'toggle', 'active', $currency['id']], ['escapeTitle' => false]); ?></span>&nbsp;&nbsp;<?php
 			if ($currency['base'] && !empty($baseCurrency)) {
 				echo $this->Format->yesNo($currency['base'], ['onTitle' => __('Base value')]);
 			} else {
-				echo $this->Html->link($this->Icon->render('check-square-o', ['title' => __('Zum Basis-Wert machen')]), ['action' => 'base', $currency['id']], ['escape' => false], 'Sicher?');
+				echo $this->Html->link($this->Icon->render('check-square-o', ['title' => __('Zum Basis-Wert machen')]), ['action' => 'base', $currency['id']], ['escapeTitle' => false], 'Sicher?');
 			} ?>
 		</td>
 		<td>
 			<?php echo $this->Time->niceDate($currency['modified']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $currency['id']], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $currency['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $currency['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $currency['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $currency['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',

--- a/templates/Admin/Currencies/toggle.php
+++ b/templates/Admin/Currencies/toggle.php
@@ -9,4 +9,4 @@
 <?php /**
  * @var \App\View\AppView $this
  */
-echo $this->Html->link($this->Format->yesNo($ajaxToggle[$model][$field]), ['action' => 'toggle', $field, $ajaxToggle[$model]['id']], ['escape' => false]);
+echo $this->Html->link($this->Format->yesNo($ajaxToggle[$model][$field]), ['action' => 'toggle', $field, $ajaxToggle[$model]['id']], ['escapeTitle' => false]);

--- a/templates/Admin/Languages/index.php
+++ b/templates/Admin/Languages/index.php
@@ -74,8 +74,8 @@ foreach ($languages as $language):
 			<?php echo $this->Time->niceDate($language['modified']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $language['id']], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $language['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $language['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $language['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $language['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',

--- a/templates/Admin/MimeTypeImages/index.php
+++ b/templates/Admin/MimeTypeImages/index.php
@@ -51,7 +51,7 @@ foreach ($mimeTypeImages as $mimeTypeImage):
 		</td>
 		<td>
 			<span class="ajaxToggling" id="ajaxToggle-<?php echo $mimeTypeImage['id']?>">
-			<?php echo $this->Html->link($this->Format->yesNo($mimeTypeImage['active'], ['onTitle' => 'Active', 'offTitle' => 'Inactive']), ['action' => 'toggleActive', $mimeTypeImage['id']], ['escape' => false]);?>
+			<?php echo $this->Html->link($this->Format->yesNo($mimeTypeImage['active'], ['onTitle' => 'Active', 'offTitle' => 'Inactive']), ['action' => 'toggleActive', $mimeTypeImage['id']], ['escapeTitle' => false]);?>
 			</span>
 
 			<?php
@@ -83,7 +83,7 @@ foreach ($mimeTypeImages as $mimeTypeImage):
 		</td>
 		<td class="actions">
 			<?php //echo $this->Html->link($this->Icon->render('view'), array('action'=>'view', $mimeTypeImage['id']), array('escape'=>false)); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $mimeTypeImage['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $mimeTypeImage['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $mimeTypeImage['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',
@@ -96,7 +96,7 @@ foreach ($mimeTypeImages as $mimeTypeImage):
 				if (isset($imageWidth) && isset($imageHeight) && $imageWidth != 16 && $imageHeight != 16) {
 					echo $this->Icon->render('expand', ['title' => __('Größe ist nicht 16x16, sondern ' . $imageWidth . 'x' . $imageHeight . '! Anpassen...')]);
 				} elseif (empty($mimeTypeImage['ext']) || !empty($mimeTypeImage['warning'])) {
-					echo $this->Html->link($this->Icon->render('google', ['title' => __('Search with Google')]), 'http://images.google.de/images?q=' . $mimeTypeImage['name'] . '+imagesize%3A16x16&btnG=Bilder-Suche', ['escape' => false]);
+					echo $this->Html->link($this->Icon->render('google', ['title' => __('Search with Google')]), 'http://images.google.de/images?q=' . $mimeTypeImage['name'] . '+imagesize%3A16x16&btnG=Bilder-Suche', ['escapeTitle' => false]);
 				}
 			?>
 		</td>

--- a/templates/Admin/MimeTypes/index.php
+++ b/templates/Admin/MimeTypes/index.php
@@ -81,7 +81,7 @@ foreach ($mimeTypes as $mimeType):
 		</td>
 		<td>
 			<span class="ajaxToggling" id="ajaxToggle-<?php echo $mimeType['id']?>">
-			<?php echo $this->Html->link($this->Format->yesNo($mimeType['active'], ['onTitle' => 'Active', 'offTitle' => 'Inactive']), ['action' => 'toggleActive', $mimeType['id']], ['escape' => false]);?>
+			<?php echo $this->Html->link($this->Format->yesNo($mimeType['active'], ['onTitle' => 'Active', 'offTitle' => 'Inactive']), ['action' => 'toggleActive', $mimeType['id']], ['escapeTitle' => false]);?>
 			</span>
 		</td>
 		<td>
@@ -94,8 +94,8 @@ foreach ($mimeTypes as $mimeType):
 			<?php echo $this->Time->niceDate($mimeType['modified']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $mimeType['id']], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $mimeType['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $mimeType['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $mimeType['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $mimeType['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',

--- a/templates/Admin/PostalCodes/index.php
+++ b/templates/Admin/PostalCodes/index.php
@@ -55,8 +55,8 @@ foreach ($postalCodes as $postalCode): ?>
 			<?php echo $this->Time->niceDate($postalCode['modified']); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $postalCode['id']], ['escape' => false]); ?>
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $postalCode['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $postalCode['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $postalCode['id']], ['escapeTitle' => false]); ?>
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $postalCode['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',

--- a/templates/Admin/States/index.php
+++ b/templates/Admin/States/index.php
@@ -67,12 +67,12 @@ foreach ($states as $state):
 
 				if (Configure::read('GoogleMap.key')) {
 					$mapMarkers = $this->GoogleMap->staticMarkers($markers);
-					echo ' ' . $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $state->lat . ',' . $state->lng, 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 5]), ['id' => 'googleMap', 'class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escape' => false, 'target' => '_blank']);
+					echo ' ' . $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $state->lat . ',' . $state->lng, 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 5]), ['id' => 'googleMap', 'class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 				} else {
 					$options = [
 						'to' => $state->lat . ',' . $state->lng,
 					];
-					echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escape' => false, 'target' => '_blank']);
+					echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 				}
 			}
 
@@ -82,9 +82,9 @@ foreach ($states as $state):
 			<?php echo $this->Time->niceDate($state->modified); ?>
 		</td>
 		<td class="actions">
-			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $state['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $state['id']], ['escapeTitle' => false]); ?>
 
-			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __('Update coordinates')]), ['action' => 'updateCoordinates', $state['id']], ['escape' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __('Update coordinates')]), ['action' => 'updateCoordinates', $state['id']], ['escapeTitle' => false]); ?>
 
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $state['id']], [
 				'escapeTitle' => false,

--- a/templates/MimeTypeImages/toggle_active.php
+++ b/templates/MimeTypeImages/toggle_active.php
@@ -7,4 +7,4 @@
 <?php /**
  * @var \App\View\AppView $this
  */
-echo $this->Html->link($this->Format->yesNo($ajaxToggle['MimeTypeImage']['active'], ['onTitle' => 'Active', 'offTitle' => 'Inactive']), ['action' => 'toggleActive', $ajaxToggle['MimeTypeImage']['id']], ['escape' => false]);?>
+echo $this->Html->link($this->Format->yesNo($ajaxToggle['MimeTypeImage']['active'], ['onTitle' => 'Active', 'offTitle' => 'Inactive']), ['action' => 'toggleActive', $ajaxToggle['MimeTypeImage']['id']], ['escapeTitle' => false]);?>

--- a/templates/MimeTypes/toggle_active.php
+++ b/templates/MimeTypes/toggle_active.php
@@ -7,4 +7,4 @@
 <?php /**
  * @var \App\View\AppView $this
  */
-echo $this->Html->link($this->Format->yesNo($ajaxToggle['active'], ['onTitle' => 'Active', 'offTitle' => 'Inactive']), ['action' => 'toggleActive', $ajaxToggle['id']], ['escape' => false]);?>
+echo $this->Html->link($this->Format->yesNo($ajaxToggle['active'], ['onTitle' => 'Active', 'offTitle' => 'Inactive']), ['action' => 'toggleActive', $ajaxToggle['id']], ['escapeTitle' => false]);?>

--- a/templates/PostalCodes/map.php
+++ b/templates/PostalCodes/map.php
@@ -57,7 +57,7 @@ foreach ($postalCodes as $postalCode) {
 	$lng = $postalCode['lng'];
 
 	$content = 'Area Code <b>' . $title . '</b>' . '<br>' . $postalCode['count'] . ' codes for this area';
-	$content .= ' ' . $this->Html->link($this->Icon->render('map'), $this->GoogleMap->mapUrl(['to' => $lat . ',' . $lng]), ['escape' => false]);
+	$content .= ' ' . $this->Html->link($this->Icon->render('map'), $this->GoogleMap->mapUrl(['to' => $lat . ',' . $lng]), ['escapeTitle' => false]);
 
 	# more correct average location
 	if (isset($postalCode['lat_sum'])) {


### PR DESCRIPTION
## Summary

39 admin and frontend template links where an icon-only or icon-prefixed title is passed to `Html->link()` were using `'escape' => false`. That option also disables escaping of url attributes (href, title, class), which is unsafe when any of those carry user-derived data. Switching to `'escapeTitle' => false` scopes the opt-out to the title only.

Builds on the recent partial sweep (commit 5c6b551) that fixed the same pattern in `Form->postButton` / `Form->button`.

PHP syntax checked on all modified files. The one remaining `'escape' => false` (in `templates/Countries/index.php` on `Paginator->sort`) is left as-is — `PaginatorHelper` doesn't support `escapeTitle`, so `escape` is the only option there.