### PR TITLE
Use escapeTitle on Paginator->sort

### DIFF
--- a/templates/Countries/index.php
+++ b/templates/Countries/index.php
@@ -9,7 +9,7 @@
 
 <table class="table">
 <tr>
-	<th><?php echo $this->Paginator->sort('sort', $this->Icon->render('filter'), ['escape' => false]);?></th>
+	<th><?php echo $this->Paginator->sort('sort', $this->Icon->render('filter'), ['escapeTitle' => false]);?></th>
 	<th><?php echo $this->Paginator->sort('name');?></th>
 	<th><?php echo $this->Paginator->sort('ori_name');?></th>
 	<th><?php echo $this->Paginator->sort('iso2');?></th>


### PR DESCRIPTION
Catches the last live `'escape' => false` in `templates/Countries/index.php` — the rest of the templates already use `'escapeTitle' => false` (the four remaining hits in admin Languages/MimeTypeImages templates are inside commented-out code and intentionally untouched).

Using `'escape' => false` on `Paginator->sort` also disables HTML escaping of attributes (URL, class, title attr), not just the title text. The narrower `'escapeTitle' => false` keeps attribute escaping on while still allowing the icon HTML in the title.

Defense-in-depth — no known exploit path because the call passes a static string, but keeping the strict default protects against future edits.
