### PR TITLE
Pass allowed_classes => false to unserialize

### DIFF
--- a/src/Currency/CurrencyLib.php
+++ b/src/Currency/CurrencyLib.php
@@ -280,7 +280,7 @@ class CurrencyLib {
 		if ($res !== false) {
 			$this->cacheFileUsed = true;
 
-			return unserialize((string)$res);
+			return unserialize((string)$res, ['allowed_classes' => false]);
 		}
 
 		return false;

--- a/src/View/Helper/MimeTypeHelper.php
+++ b/src/View/Helper/MimeTypeHelper.php
@@ -143,7 +143,7 @@ class MimeTypeHelper extends Helper {
 			if ($content === false) {
 				return [];
 			}
-			$content = unserialize($content);
+			$content = unserialize($content, ['allowed_classes' => false]);
 			if ($content === false || !is_array($content)) {
 				return [];
 			}


### PR DESCRIPTION
## Issue

Two `unserialize()` calls in `cakephp-data` did not restrict deserialization classes:

- `src/Currency/CurrencyLib.php:280` — reads from `Cake\Cache`
- `src/View/Helper/MimeTypeHelper.php:143` — reads from a file cache (`FILE_CACHE.mime_types.txt`)

Both stores are written by this plugin's own `_store` / write paths, and both serialize only plain primitive arrays (no objects). Restricting deserialization to non-objects therefore has no behavioral effect, and closes the gadget-chain attack surface in case:

- the cache backend is shared with another app that an attacker can poison,
- the file cache is writable by an attacker process, or
- future code accidentally caches an object.

## Fix

```diff
- unserialize($content);
+ unserialize($content, ['allowed_classes' => false]);
```

Defense-in-depth, no BC impact.
