### PR TITLE
Switch ECB/LoC feeds to HTTPS and migrate stale validate arrays

### DIFF
--- a/src/Currency/CurrencyLib.php
+++ b/src/Currency/CurrencyLib.php
@@ -27,18 +27,18 @@ class CurrencyLib {
 	/**
 	 * @var string
 	 */
-	public const URL = 'http://www.ecb.int/stats/eurofxref/eurofxref-daily.xml';
+	public const URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml';
 
 	/**
 	 * @var string
 	 */
-	public const URL_HISTORY = 'http://www.ecb.int/stats/eurofxref/eurofxref-hist.xml';
+	public const URL_HISTORY = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml';
 
 	//TODO: get information about a currency (name, ...)
 	/**
 	 * @var string
 	 */
-	public const URL_TABLE = 'http://www.ecb.int/rss/fxref-{currency}.html';
+	public const URL_TABLE = 'https://www.ecb.europa.eu/rss/fxref-{currency}.html';
 
 	/**
 	 * @var string

--- a/src/Model/Table/AddressesTable.php
+++ b/src/Model/Table/AddressesTable.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
+use Cake\Validation\Validator;
 use Data\Model\Entity\Address;
 use Tools\Model\Table\Table;
 
@@ -45,84 +46,71 @@ class AddressesTable extends Table {
 	protected array $order = ['type_id' => 'ASC', 'formatted_address' => 'ASC'];
 
 	/**
-	 * @var array
+	 * Default validation rules.
+	 *
+	 * @param \Cake\Validation\Validator $validator Validator instance.
+	 * @return \Cake\Validation\Validator
 	 */
-	public array $validate = [
-		'state_id' => [
-			'numeric' => [
-				'rule' => ['numeric'],
-				'message' => 'valErrMandatoryField',
-				'last' => true,
-			],
-			'fitsToCountry' => [
-				'rule' => ['fitsToCountry'],
-				'message' => 'The province seems not be fit to the chosen country',
+	public function validationDefault(Validator $validator): Validator {
+		$validator
+			->integer('state_id')
+			->allowEmptyString('state_id')
+			->add('state_id', 'fitsToCountry', [
+				'rule' => 'fitsToCountry',
+				'message' => __('The province seems not be fit to the chosen country'),
 				'provider' => 'table',
-			],
-		],
-		'country_id' => [
-			'numeric' => [
-				'rule' => ['numeric'],
-				'message' => 'valErrMandatoryField',
-				'last' => true,
-			],
-		],
-		'address_type_id' => [
-			'numeric' => [
-				'rule' => ['numeric'],
-				'message' => 'valErrMandatoryField',
-				'last' => true,
-			],
-			'primaryUnique' => [
-				'rule' => ['primaryUnique'],
-				'message' => 'Es darf nur eine Adresse "Haupt-Wohnsitz" sein, bitte einen anderen Typ wählen',
+			]);
+
+		$validator
+			->integer('country_id')
+			->allowEmptyString('country_id');
+
+		$validator
+			->integer('address_type_id')
+			->allowEmptyString('address_type_id')
+			->add('address_type_id', 'primaryUnique', [
+				'rule' => 'primaryUnique',
+				'message' => __('Only one address can be marked as "Main Residence", please choose another type'),
 				'last' => true,
 				'provider' => 'table',
-			],
-		],
-		'foreign_id' => [],
-		'postal_code' => [
-			'notBlank' => [
-				'rule' => ['notBlank'],
-				'message' => 'valErrMandatoryField',
-				'last' => true,
-			],
-			'correspondsWithCountry' => [
-				'rule' => ['correspondsWithCountry'],
-				'message' => 'The zip code seems not to have the correct length',
+			]);
+
+		$validator
+			->scalar('postal_code')
+			->allowEmptyString('postal_code')
+			->add('postal_code', 'correspondsWithCountry', [
+				'rule' => 'correspondsWithCountry',
+				'message' => __('The zip code seems not to have the correct length'),
 				'provider' => 'table',
-			],
-		],
-		'city' => [
-			'notBlank' => [
-				'rule' => ['notBlank'],
-				'message' => 'valErrMandatoryField',
-			],
-		],
-		'street' => [],
-		'formatted_address' => [
-			'validateUnique' => [
+			]);
+
+		$validator
+			->scalar('city')
+			->allowEmptyString('city');
+
+		$validator
+			->scalar('street')
+			->allowEmptyString('street');
+
+		$validator
+			->scalar('formatted_address')
+			->allowEmptyString('formatted_address')
+			->add('formatted_address', 'validateUnique', [
 				'rule' => ['validateUnique', ['scope' => ['foreign_id', 'model']]],
-				'allowEmpty' => true,
-				'message' => 'valErrRecordNameExists',
+				'message' => __('valErrRecordNameExists'),
 				'provider' => 'table',
-			],
-		],
-		'lat' => [
-			'decimal' => [
-				'rule' => ['decimal', 6],
-				'allowEmpty' => true,
-				'message' => 'not a valid geografic number for latitude',
-			],
-		],
-		'lng' => [
-			'decimal' => [
-				'rule' => ['decimal', 6],
-				'allowEmpty' => true,
-				'message' => 'not a valid geografic number for longitude',
-			],
-		],
-	];
+			]);
+
+		$validator
+			->decimal('lat', 6, __('not a valid geografic number for latitude'))
+			->allowEmptyString('lat');
+
+		$validator
+			->decimal('lng', 6, __('not a valid geografic number for longitude'))
+			->allowEmptyString('lng');
+
+		return $validator;
+	}
 
 	/**
 	 * @param array $config

--- a/src/Model/Table/DistrictsTable.php
+++ b/src/Model/Table/DistrictsTable.php
@@ -4,6 +4,7 @@ namespace Data\Model\Table;
 
 use ArrayObject;
 use Cake\Event\EventInterface;
+use Cake\Validation\Validator;
 use Tools\Model\Table\Table;
 
 /**
@@ -19,22 +20,22 @@ class DistrictsTable extends Table {
 	protected array $order = ['name' => 'ASC'];
 
 	/**
-	 * @var array
+	 * Default validation rules.
+	 *
+	 * @param \Cake\Validation\Validator $validator Validator instance.
+	 * @return \Cake\Validation\Validator
 	 */
-	public array $validate = [
-		'name' => [
-			'notBlank' => [
-				'rule' => ['notBlank'],
-				'message' => 'valErrMandatoryField',
-			],
-		],
-		'city_id' => [
-			'numeric' => [
-				'rule' => ['numeric'],
-				'message' => 'valErrMandatoryField',
-			],
-		],
-	];
+	public function validationDefault(Validator $validator): Validator {
+		$validator
+			->scalar('name')
+			->notEmptyString('name', __('valErrMandatoryField'));
+
+		$validator
+			->integer('city_id')
+			->notEmptyString('city_id', __('valErrMandatoryField'));
+
+		return $validator;
+	}
 
 	/**
 	 * @param array $config

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -7,9 +7,11 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Event\EventInterface;
+use Cake\Http\Client;
 use Data\HtmlDom\HtmlDom;
 use Data\Model\Entity\Language;
 use Data\Utility\L10n;
+use RuntimeException;
 use Tools\Model\Table\Table;
 
 /**
@@ -253,14 +255,20 @@ class LanguagesTable extends Table {
 	}
 
 	/**
+	 * @throws \RuntimeException If the ISO 639-2 list cannot be fetched.
+	 *
 	 * @return array Array 2d heading and values
 	 */
 	public function getOfficialIsoList() {
 		$HtmlDom = new HtmlDom();
 		$res = Cache::read('lov_gov_iso_list');
 		if (!$res) {
-			$res = (string)file_get_contents('http://www.loc.gov/standards/iso639-2/php/code_list.php');
-			$res = $HtmlDom->domFromString($res);
+			$client = new Client(['timeout' => 5]);
+			$response = $client->get('https://www.loc.gov/standards/iso639-2/php/code_list.php');
+			if (!$response->isOk()) {
+				throw new RuntimeException('Cannot load ISO 639-2 list from loc.gov');
+			}
+			$res = $HtmlDom->domFromString($response->getStringBody());
 			Cache::write('lov_gov_iso_list', $res);
 		}
 

--- a/src/Model/Table/LocationsTable.php
+++ b/src/Model/Table/LocationsTable.php
@@ -7,6 +7,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Log\Log;
 use Cake\Validation\Validation;
+use Cake\Validation\Validator;
 use Tools\Model\Table\Table;
 use Tools\Utility\Utility;
 
@@ -25,29 +26,27 @@ class LocationsTable extends Table {
 	];
 
 	/**
-	 * @var array
+	 * Default validation rules.
+	 *
+	 * @param \Cake\Validation\Validator $validator Validator instance.
+	 * @return \Cake\Validation\Validator
 	 */
-	public array $validate = [
-		'name' => [
-			'notBlank' => [
-				'rule' => ['notBlank'],
-				'message' => 'valErrMandatoryField',
-				'last' => true,
-			],
-			'unique' => [
+	public function validationDefault(Validator $validator): Validator {
+		$validator
+			->scalar('name')
+			->notEmptyString('name', __('valErrMandatoryField'))
+			->add('name', 'unique', [
 				'rule' => ['validateUnique', ['scope' => ['country_id']]],
-				'message' => 'valErrRecordNameExists',
+				'message' => __('valErrRecordNameExists'),
 				'provider' => 'table',
-			],
-		],
-		'country_id' => [
-			'numeric' => [
-				'rule' => ['numeric'],
-				'message' => 'valErrMandatoryField',
-				'last' => true,
-			],
-		],
-	];
+			]);
+
+		$validator
+			->integer('country_id')
+			->notEmptyString('country_id', __('valErrMandatoryField'));
+
+		return $validator;
+	}
 
 	/**
 	 * FIXME


### PR DESCRIPTION
## Summary

Three fixes covering MITM-class outgoing fetches and dead validation rules that the CakePHP 5 ORM never executed.

### HTTPS for ECB currency feeds

`src/Currency/CurrencyLib.php:30,35,41` was fetching ECB exchange rates over plain HTTP from the legacy `www.ecb.int` host. Replaced all three constants (`URL`, `URL_HISTORY`, `URL_TABLE`) with HTTPS on the canonical `www.ecb.europa.eu` host. The values feed `convert()`, `table()`, `history()` plus a cached XML round-trip; previously a network attacker could inject arbitrary XML into the cached payload.

### HTTPS + timeout for the LoC ISO list fetch

`src/Model/Table/LanguagesTable.php:262` (`getOfficialIsoList()`) was calling `file_get_contents('http://www.loc.gov/...')` with no timeout, no error handling, and no TLS. Replaced with `Cake\Http\Client` over HTTPS, 5 second timeout, `isOk()` check, and `RuntimeException` on fetch failure — same pattern already in `Sync/Countries.php` and `Sync/Timezones.php`.

### Migrate `$validate` to `validationDefault()` in three Tables

`AddressesTable`, `DistrictsTable`, and `LocationsTable` still carried CakePHP-2.x-style `public array $validate` blocks. The Cake 5 ORM never reads that property, so the rules were dead code, not active validation — `AddressesTable` had no server-side validation in production. Ported each block to `validationDefault(Validator $validator): Validator` so the rules actually run on save. Custom rule providers (`primaryUnique`, `correspondsWithCountry`, `fitsToCountry`) are preserved via the `'table'` provider. The German `'Es darf nur eine Adresse "Haupt-Wohnsitz" sein'` validation message in `AddressesTable` is now passed through `__()`.

### Verification

- `vendor/bin/phpunit` — 102 tests green
- `vendor/bin/phpstan analyze` (level 8) — 0 errors
- `vendor/bin/phpcs src/` — clean
