### PR TITLE
Fix Countries demo pagination sort icon

### DIFF
--- a/templates/Countries/index.php
+++ b/templates/Countries/index.php
@@ -9,7 +9,7 @@
 
 <table class="table">
 <tr>
-	<th><?php echo $this->Paginator->sort('sort', $this->Icon->render('filter'), ['escapeTitle' => false]);?></th>
+	<th><?php echo $this->Paginator->sort('sort', $this->Icon->render('filter'), ['escape' => false]);?></th>
 	<th><?php echo $this->Paginator->sort('name');?></th>
 	<th><?php echo $this->Paginator->sort('ori_name');?></th>
 	<th><?php echo $this->Paginator->sort('iso2');?></th>


### PR DESCRIPTION
## Summary

`Paginator->sort()` only honors `'escape' => false` — `'escapeTitle' => false` is silently ignored. The FontAwesome filter icon in the Countries demo fell back to the default escaped path and rendered as literal HTML text.

## Fix

Switch the `Paginator->sort()` call in `templates/Countries/index.php` to `'escape' => false`. Verified in CakePHP source: `PaginatorHelper::sort` uses only the `escape` option.