### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/data.pot
+++ b/resources/locales/data.pot
@@ -1,0 +1,595 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 02:23+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "record add {0} saved"
+msgstr ""
+
+msgid "formContainsErrors"
+msgstr ""
+
+msgid "record edit {0} saved"
+msgstr ""
+
+msgid "record del {0} done"
+msgstr ""
+
+msgid "record del {0} not done exception"
+msgstr ""
+
+msgid "Address '{0}' marked as last used"
+msgstr ""
+
+msgid " - n/a - "
+msgstr ""
+
+msgid "record add not saved"
+msgstr ""
+
+msgid "record edit not saved"
+msgstr ""
+
+msgid "noBaseCurrency"
+msgstr ""
+
+msgid "set as primary {0} done"
+msgstr ""
+
+msgid "set as primary not done exception"
+msgstr ""
+
+msgid "Saved"
+msgstr ""
+
+msgid "languages added"
+msgstr ""
+
+msgid "not added"
+msgstr ""
+
+msgid "{0} of {1} set active"
+msgstr ""
+
+msgid "re-rendered"
+msgstr ""
+
+msgid "record invalid"
+msgstr ""
+
+msgid "record del not exists"
+msgstr ""
+
+msgid "The timezone has been saved."
+msgstr ""
+
+msgid "The timezone could not be saved. Please, try again."
+msgstr ""
+
+msgid "The timezone has been deleted."
+msgstr ""
+
+msgid "The timezone could not be deleted. Please, try again."
+msgstr ""
+
+msgid "Main Residence"
+msgstr ""
+
+msgid "Other"
+msgstr ""
+
+msgid "Inactive"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "The province seems not be fit to the chosen country"
+msgstr ""
+
+msgid "Only one address can be marked as \"Main Residence\", please choose another type"
+msgstr ""
+
+msgid "The zip code seems not to have the correct length"
+msgstr ""
+
+msgid "valErrRecordNameExists"
+msgstr ""
+
+msgid "not a valid geografic number for latitude"
+msgstr ""
+
+msgid "not a valid geografic number for longitude"
+msgstr ""
+
+msgid "valErrMandatoryField"
+msgstr ""
+
+msgid "Germany"
+msgstr ""
+
+msgid "GIF (*.gif)"
+msgstr ""
+
+msgid "PNG (*.png)"
+msgstr ""
+
+msgid "JPG (*.jpg)"
+msgstr ""
+
+msgid "MimeType"
+msgstr ""
+
+msgid "Addresses"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Add {0}"
+msgstr ""
+
+msgid "Address"
+msgstr ""
+
+msgid "User"
+msgstr ""
+
+msgid "Model"
+msgstr ""
+
+msgid "Country"
+msgstr ""
+
+msgid "Country Province"
+msgstr ""
+
+msgid "First Name"
+msgstr ""
+
+msgid "Last Name"
+msgstr ""
+
+msgid "Street"
+msgstr ""
+
+msgid "Postal Code"
+msgstr ""
+
+msgid "City"
+msgstr ""
+
+msgid "Lat"
+msgstr ""
+
+msgid "Lng"
+msgstr ""
+
+msgid "Last Used"
+msgstr ""
+
+msgid "Formatted Address"
+msgstr ""
+
+msgid "Edit {0}"
+msgstr ""
+
+msgid "Delete {0}"
+msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "List {0}"
+msgstr ""
+
+msgid "noSelection"
+msgstr ""
+
+msgid "Relations"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Coordinates"
+msgstr ""
+
+msgid "Show"
+msgstr ""
+
+msgid "click for full map"
+msgstr ""
+
+msgid "Debug"
+msgstr ""
+
+msgid "Mark as {0}"
+msgstr ""
+
+msgid "Used"
+msgstr ""
+
+msgid "Cities"
+msgstr ""
+
+msgid "New {0}"
+msgstr ""
+
+msgid "Country Id"
+msgstr ""
+
+msgid "Official Id"
+msgstr ""
+
+msgid "County Id"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Citizens"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Postal Code Unique"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Continent"
+msgstr ""
+
+msgid "Continents"
+msgstr ""
+
+msgid "Tree"
+msgstr ""
+
+msgid "Ori Name"
+msgstr ""
+
+msgid "Code"
+msgstr ""
+
+msgid "Parent Continent"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Countries"
+msgstr ""
+
+msgid "wildcardSearch {0} and {1}"
+msgstr ""
+
+msgid "Search"
+msgstr ""
+
+msgid "n/a"
+msgstr ""
+
+msgid "Koordinaten updaten"
+msgstr ""
+
+msgid "Sync"
+msgstr ""
+
+msgid "Icons"
+msgstr ""
+
+msgid "Sync Countries"
+msgstr ""
+
+msgid "Iso2"
+msgstr ""
+
+msgid "Iso3"
+msgstr ""
+
+msgid "Phone Code"
+msgstr ""
+
+msgid "Timezone"
+msgstr ""
+
+msgid "Special"
+msgstr ""
+
+msgid "Address Format"
+msgstr ""
+
+msgid "Delete Country"
+msgstr ""
+
+msgid "Currency"
+msgstr ""
+
+msgid "Currencies"
+msgstr ""
+
+msgid "Base value"
+msgstr ""
+
+msgid "Zum Basis-Wert machen"
+msgstr ""
+
+msgid "Update {0}"
+msgstr ""
+
+msgid "Currency Values"
+msgstr ""
+
+msgid "Full Currency Table"
+msgstr ""
+
+msgid "Symbol Left"
+msgstr ""
+
+msgid "Symbol Right"
+msgstr ""
+
+msgid "Decimal Places"
+msgstr ""
+
+msgid "Value"
+msgstr ""
+
+msgid "Delete Currency"
+msgstr ""
+
+msgid "Language"
+msgstr ""
+
+msgid "Languages"
+msgstr ""
+
+msgid "Locale"
+msgstr ""
+
+msgid "Locales"
+msgstr ""
+
+msgid "Import {0}"
+msgstr ""
+
+msgid "Direction"
+msgstr ""
+
+msgid "Compare {0}"
+msgstr ""
+
+msgid "Compare {0} to core"
+msgstr ""
+
+msgid "Import {0} from Core"
+msgstr ""
+
+msgid "Sure?"
+msgstr ""
+
+msgid "Set primary languages active"
+msgstr ""
+
+msgid "Locale Fallback"
+msgstr ""
+
+msgid "Add Mime Type Image"
+msgstr ""
+
+msgid "List Mime Type Images"
+msgstr ""
+
+msgid "Edit Mime Type Image"
+msgstr ""
+
+msgid "Confirm and Save"
+msgstr ""
+
+msgid "Extensions"
+msgstr ""
+
+msgid "Mime Type Images"
+msgstr ""
+
+msgid "Icon"
+msgstr ""
+
+msgid "Usage"
+msgstr ""
+
+msgid "Größe ist nicht 16x16, sondern "
+msgstr ""
+
+msgid "Search with Google"
+msgstr ""
+
+msgid "(Auto-) Allocate Icons Files"
+msgstr ""
+
+msgid "Import Extensions"
+msgstr ""
+
+msgid "Search Icon on google.de"
+msgstr ""
+
+msgid "Mime Type Image"
+msgstr ""
+
+msgid "Ext"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Delete Mime Type Image"
+msgstr ""
+
+msgid "Add Mime Type"
+msgstr ""
+
+msgid "List Mime Types"
+msgstr ""
+
+msgid "Mime Type Detection"
+msgstr ""
+
+msgid "Test"
+msgstr ""
+
+msgid "Edit Mime Type"
+msgstr ""
+
+msgid "Mime Types"
+msgstr ""
+
+msgid " out of "
+msgstr ""
+
+msgid "(Auto-) Allocate Icons by Extension"
+msgstr ""
+
+msgid "Allocate Icons by Type (Groups)"
+msgstr ""
+
+msgid "Import from Core Media View"
+msgstr ""
+
+msgid "Import from File"
+msgstr ""
+
+msgid "Manual Input"
+msgstr ""
+
+msgid "Mime Type"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Delete Mime Type"
+msgstr ""
+
+msgid "Postal Codes"
+msgstr ""
+
+msgid "Placeholder"
+msgstr ""
+
+msgid "Query"
+msgstr ""
+
+msgid "Geolocate"
+msgstr ""
+
+msgid "Query {0}"
+msgstr ""
+
+msgid "Geo Data"
+msgstr ""
+
+msgid "Enter Postal Code, City, Address or other Geo Data"
+msgstr ""
+
+msgid "Map"
+msgstr ""
+
+msgid "Official Address"
+msgstr ""
+
+msgid "State"
+msgstr ""
+
+msgid "pleaseSelect"
+msgstr ""
+
+msgid "States"
+msgstr ""
+
+msgid "Update coordinates"
+msgstr ""
+
+msgid "Update Coordinates"
+msgstr ""
+
+msgid "Add State"
+msgstr ""
+
+msgid "noOptionAvailable"
+msgstr ""
+
+msgid "List Timezones"
+msgstr ""
+
+msgid "Timezones"
+msgstr ""
+
+msgid "Add Timezone"
+msgstr ""
+
+msgid "Edit Timezone"
+msgstr ""
+
+msgid "Link Timezones"
+msgstr ""
+
+msgid "Sync Timezones"
+msgstr ""
+
+msgid "Country Code"
+msgstr ""
+
+msgid "Offset"
+msgstr ""
+
+msgid "Offset Dst"
+msgstr ""
+
+msgid "Covered"
+msgstr ""
+
+msgid "Notes"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "countryCodeExplanation"
+msgstr ""
+
+msgid "Note"
+msgstr ""
+
+msgid "Legend"
+msgstr ""
+
+msgid "Search {0}"
+msgstr ""
+
+msgid "Area Code"
+msgstr ""
+
+msgid "noRestriction"
+msgstr ""
+

--- a/src/Controller/Admin/AddressesController.php
+++ b/src/Controller/Admin/AddressesController.php
@@ -41,11 +41,11 @@ class AddressesController extends DataAppController {
 			$address = $this->Addresses->patchEntity($address, $this->request->getData());
 			if ($this->Addresses->save($address)) {
 				$var = $address['formatted_address'];
-				$this->Flash->success(__('record add {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record add {0} saved', h($var)));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 
 		} else {
 			# TODO: geolocate via IP? only for frontend
@@ -74,11 +74,11 @@ class AddressesController extends DataAppController {
 
 			if ($this->Addresses->save($address)) {
 				$var = $address['formatted_address'];
-				$this->Flash->success(__('record edit {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record edit {0} saved', h($var)));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 
 		}
 		if (!$this->request->getData()) {
@@ -112,11 +112,11 @@ class AddressesController extends DataAppController {
 		$var = $address['formatted_address'];
 
 		if ($this->Addresses->delete($address)) {
-			$this->Flash->success(__('record del {0} done', h($var)));
+			$this->Flash->success(__d('data', 'record del {0} done', h($var)));
 
 			return $this->redirect(['action' => 'index']);
 		}
-		$this->Flash->error(__('record del {0} not done exception', h($var)));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', h($var)));
 
 		return $this->Common->autoRedirect(['action' => 'index']);
 	}
@@ -133,7 +133,7 @@ class AddressesController extends DataAppController {
 		$addressId = $address->id;
 		$this->Addresses->touch($addressId);
 		$var = $address['formatted_address'];
-		$this->Flash->success(__('Address \'{0}\' marked as last used', h($var)));
+		$this->Flash->success(__d('data', 'Address \'{0}\' marked as last used', h($var)));
 
 		return $this->Common->autoRedirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/CitiesController.php
+++ b/src/Controller/Admin/CitiesController.php
@@ -49,11 +49,11 @@ class CitiesController extends DataAppController {
 		if ($this->Common->isPosted()) {
 			if ($this->Cities->save($this->request->getData())) {
 				$var = $city['name'];
-				$this->Flash->success(__('record add {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record add {0} saved', h($var)));
 
 				return $this->Common->postRedirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 
 		}
 
@@ -73,11 +73,11 @@ class CitiesController extends DataAppController {
 
 			if ($this->Cities->save($city)) {
 				$var = $city['name'];
-				$this->Flash->success(__('record edit {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record edit {0} saved', h($var)));
 
 				return $this->Common->postRedirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 		}
 
 		$countries = $this->Cities->Countries->find('list');
@@ -95,11 +95,11 @@ class CitiesController extends DataAppController {
 		$var = $city['name'];
 
 		if ($this->Cities->delete($city)) {
-			$this->Flash->success(__('record del {0} done', h($var)));
+			$this->Flash->success(__d('data', 'record del {0} done', h($var)));
 
 			return $this->redirect(['action' => 'index']);
 		}
-		$this->Flash->error(__('record del {0} not done exception', h($var)));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', h($var)));
 
 		return $this->Common->autoRedirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/ContinentsController.php
+++ b/src/Controller/Admin/ContinentsController.php
@@ -59,14 +59,14 @@ class ContinentsController extends DataAppController {
 			$continent = $this->Continents->patchEntity($continent, $this->request->getData());
 			if ($this->Continents->save($continent)) {
 				$var = $continent['name'];
-				$this->Flash->success(__('record add {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record add {0} saved', h($var)));
 
 				return $this->Common->postRedirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 		}
-		$parents = ['' => __(' - n/a - ')] + $this->Continents->ParentContinents->find('treeList', ...['spacer' => '» '])->toArray();
+		$parents = ['' => __d('data', ' - n/a - ')] + $this->Continents->ParentContinents->find('treeList', ...['spacer' => '» '])->toArray();
 		$this->set(compact('continent', 'parents'));
 	}
 
@@ -82,15 +82,15 @@ class ContinentsController extends DataAppController {
 			$continent = $this->Continents->patchEntity($continent, $this->request->getData());
 			if ($this->Continents->save($continent)) {
 				$var = $continent['name'];
-				$this->Flash->success(__('record edit {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record edit {0} saved', h($var)));
 
 				return $this->Common->postRedirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 		}
 
-		$parents = ['' => __(' - n/a - ')] + $this->Continents->ParentContinents->find('treeList', ...['spacer' => '» '])->toArray();
+		$parents = ['' => __d('data', ' - n/a - ')] + $this->Continents->ParentContinents->find('treeList', ...['spacer' => '» '])->toArray();
 		$this->set(compact('continent', 'parents'));
 	}
 
@@ -106,11 +106,11 @@ class ContinentsController extends DataAppController {
 		$var = $continent['name'];
 
 		if ($this->Continents->delete($continent)) {
-			$this->Flash->success(__('record del {0} done', h($var)));
+			$this->Flash->success(__d('data', 'record del {0} done', h($var)));
 
 			return $this->redirect(['action' => 'index']);
 		}
-		$this->Flash->error(__('record del {0} not done exception', h($var)));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', h($var)));
 
 		return $this->Common->autoRedirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/CountriesController.php
+++ b/src/Controller/Admin/CountriesController.php
@@ -199,12 +199,12 @@ class CountriesController extends DataAppController {
 			if ($this->Countries->save($country)) {
 				$id = $country->id;
 				//$name = $this->request->data['name'];
-				$this->Flash->success(__('record add {0} saved', $id));
+				$this->Flash->success(__d('data', 'record add {0} saved', $id));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record add not saved'));
+			$this->Flash->error(__d('data', 'record add not saved'));
 		}
 
 		$this->set(compact('country'));
@@ -222,12 +222,12 @@ class CountriesController extends DataAppController {
 			$country = $this->Countries->patchEntity($country, $this->request->getData());
 			if ($this->Countries->save($country)) {
 				$name = $country->name;
-				$this->Flash->success(__('record edit {0} saved', h($name)));
+				$this->Flash->success(__d('data', 'record edit {0} saved', h($name)));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record edit not saved'));
+			$this->Flash->error(__d('data', 'record edit not saved'));
 		}
 
 		$continents = [];
@@ -246,12 +246,12 @@ class CountriesController extends DataAppController {
 		$country = $this->Countries->get($id);
 
 		if ($this->Countries->delete($country)) {
-			$this->Flash->success(__('record del {0} done', $id));
+			$this->Flash->success(__d('data', 'record del {0} done', $id));
 
 			return $this->redirect(['action' => 'index']);
 		}
 
-		$this->Flash->error(__('record del {0} not done exception', $id));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', $id));
 
 		return $this->redirect(['action' => 'index']);
 	}
@@ -259,7 +259,7 @@ class CountriesController extends DataAppController {
 	/*
 	public function up($id = null) {
 		if (empty($id) || !($navigation = $this->Countries->find('first', ['conditions' => ['Countries.id' => $id]]))) {
-			$this->Flash->error(__('invalid record'));
+			$this->Flash->error(__d('data', 'invalid record'));
 			return $this->Common->autoRedirect(['action' => 'index']);
 		}
 		$this->Countries->moveDown($id, 1);
@@ -268,7 +268,7 @@ class CountriesController extends DataAppController {
 
 	public function down($id = null) {
 		if (empty($id) || !($navigation = $this->Countries->find('first', ['conditions' => ['Countries.id' => $id]]))) {
-			$this->Flash->error(__('invalid record'));
+			$this->Flash->error(__d('data', 'invalid record'));
 			return $this->Common->autoRedirect(['action' => 'index']);
 		}
 		$this->Countries->moveUp($id, 1);

--- a/src/Controller/Admin/CurrenciesController.php
+++ b/src/Controller/Admin/CurrenciesController.php
@@ -61,7 +61,7 @@ class CurrenciesController extends DataAppController {
 		if (!$baseCurrency) {
 			$baseCurrency = $this->Currencies->find('all', ...['conditions' => ['base' => true]])->first();
 			if (!$baseCurrency) {
-				$this->Flash->warning(__('noBaseCurrency'));
+				$this->Flash->warning(__d('data', 'noBaseCurrency'));
 			}
 		}
 
@@ -90,12 +90,12 @@ class CurrenciesController extends DataAppController {
 			if ($this->Currencies->save($currency)) {
 				$id = $currency->id;
 				//$name = $this->request->data['Currency']['name'];
-				$this->Flash->success(__('record add {0} saved', $id));
+				$this->Flash->success(__d('data', 'record add {0} saved', $id));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record add not saved'));
+			$this->Flash->error(__d('data', 'record add not saved'));
 		} else {
 			$this->request = $this->request->withData('decimal_places', 2);
 		}
@@ -115,12 +115,12 @@ class CurrenciesController extends DataAppController {
 			$currency = $this->Currencies->patchEntity($currency, $this->request->getData());
 			if ($this->Currencies->save($currency)) {
 				//$name = $this->request->data['Currency']['name'];
-				$this->Flash->success(__('record edit {0} saved', $id));
+				$this->Flash->success(__d('data', 'record edit {0} saved', $id));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record edit not saved'));
+			$this->Flash->error(__d('data', 'record edit not saved'));
 		}
 
 		$this->set(compact('currency'));
@@ -135,12 +135,12 @@ class CurrenciesController extends DataAppController {
 		$currency = $this->Currencies->get($id);
 
 		if ($this->Currencies->delete($currency)) {
-			$this->Flash->success(__('record del {0} done', $id));
+			$this->Flash->success(__d('data', 'record del {0} done', $id));
 
 			return $this->redirect(['action' => 'index']);
 		}
 
-		$this->Flash->error(__('record del {0} not done exception', $id));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', $id));
 
 		return $this->Common->autoRedirect(['action' => 'index']);
 	}
@@ -168,9 +168,9 @@ class CurrenciesController extends DataAppController {
 
 		$name = '';
 		if (!empty($value)) {
-			$this->Flash->success(__('set as primary {0} done', h($name)));
+			$this->Flash->success(__d('data', 'set as primary {0} done', h($name)));
 		} else {
-			$this->Flash->error(__('set as primary not done exception', $name));
+			$this->Flash->error(__d('data', 'set as primary not done exception', $name));
 
 		}
 
@@ -193,7 +193,7 @@ class CurrenciesController extends DataAppController {
 
 		# http get request + redirect
 		if (!$this->request->is('ajax')) {
-			$this->Flash->success(__('Saved'));
+			$this->Flash->success(__d('data', 'Saved'));
 
 			return $this->Common->autoRedirect(['action' => 'index']);
 		}

--- a/src/Controller/Admin/LanguagesController.php
+++ b/src/Controller/Admin/LanguagesController.php
@@ -73,12 +73,12 @@ class LanguagesController extends DataAppController {
 			$language = $this->Languages->patchEntity($language, $this->request->getData());
 			if ($this->Languages->save($language)) {
 				$var = $language['name'];
-				$this->Flash->success(__('record add {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record add {0} saved', h($var)));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 		}
 
 		$this->set(compact('language'));
@@ -97,12 +97,12 @@ class LanguagesController extends DataAppController {
 
 			if ($this->Languages->save($language)) {
 				$var = $language->name;
-				$this->Flash->success(__('record edit {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record edit {0} saved', h($var)));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 		}
 
 		$this->set(compact('language'));
@@ -119,7 +119,7 @@ class LanguagesController extends DataAppController {
 		$language = $this->Languages->get($id);
 		if ($this->Languages->delete($language)) {
 			$var = $language['name'];
-			$this->Flash->success(__('record del {0} done', h($var)));
+			$this->Flash->success(__d('data', 'record del {0} done', h($var)));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -159,13 +159,13 @@ class LanguagesController extends DataAppController {
 			}
 		}
 
-		$this->Flash->success($count . ' of ' . count($languages) . ' ' . __('languages added'));
+		$this->Flash->success($count . ' of ' . count($languages) . ' ' . __d('data', 'languages added'));
 
 		$errorMessage = [];
 		foreach ($errors as $error) {
 			$errorMessage[] = $error['data'] . ' (' . json_encode($error['errors']) . ')';
 		}
-		$this->Flash->warning(__('not added') . ' ' . implode(', ', $errorMessage));
+		$this->Flash->warning(__d('data', 'not added') . ' ' . implode(', ', $errorMessage));
 
 		return $this->redirect(['action' => 'index']);
 	}
@@ -222,7 +222,7 @@ class LanguagesController extends DataAppController {
 		$languages = $this->Languages->getPrimaryLanguages('list')->toArray();
 		$count = $this->Languages->updateAll(['status' => Language::STATUS_ACTIVE], ['id' => array_keys($languages)]);
 
-		$this->Flash->success(__('{0} of {1} set active', $count, count($languages)));
+		$this->Flash->success(__d('data', '{0} of {1} set active', $count, count($languages)));
 
 		return $this->redirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/MimeTypeImagesController.php
+++ b/src/Controller/Admin/MimeTypeImagesController.php
@@ -302,7 +302,7 @@ class MimeTypeImagesController extends DataAppController {
 		if (!array_key_exists($ext, MimeTypeImagesTable::extensions()) || ($this->request->getData('ext') && $this->request->getData('ext') !=
 			$ext)) {
 			# re-render
-			$this->Flash->success(__('re-rendered'));
+			$this->Flash->success(__d('data', 're-rendered'));
 
 			/*
 			if (!empty($this->request->data['ext'])) {
@@ -350,12 +350,12 @@ class MimeTypeImagesController extends DataAppController {
 			if (empty($error) && $this->MimeTypeImages->save($mimeTypeImage)) {
 				$id = $mimeTypeImage->id;
 				//$name = $this->request->data['name'];
-				$this->Flash->success(__('record add {0} saved', $id));
+				$this->Flash->success(__d('data', 'record add {0} saved', $id));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record add not saved'));
+			$this->Flash->error(__d('data', 'record add not saved'));
 		} else {
 			//$this->request->data['active'] = 1;
 		}
@@ -392,12 +392,12 @@ class MimeTypeImagesController extends DataAppController {
 
 			if ($this->MimeTypeImages->save($this->request->getData())) {
 				//$name = $this->request->data['name'];
-				$this->Flash->success(__('record edit {0} saved', $id));
+				$this->Flash->success(__d('data', 'record edit {0} saved', $id));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record edit not saved'));
+			$this->Flash->error(__d('data', 'record edit not saved'));
 		}
 
 		$folder = new Folder(PATH_MIMETYPES . 'import' . DS);
@@ -426,12 +426,12 @@ class MimeTypeImagesController extends DataAppController {
 		//$this->MimeTypeImages->MimeTypes->updateAll(['mime_type_image_id' => null], ['mime_type_image_id' => $id]);
 
 		if ($this->MimeTypeImages->delete($mimeTypeImage)) {
-			$this->Flash->success(__('record del {0} done', $name));
+			$this->Flash->success(__d('data', 'record del {0} done', $name));
 
 			return $this->Common->autoRedirect(['action' => 'index']);
 		}
 
-		$this->Flash->error(__('record del {0} not done exception', $name));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', $name));
 
 		return $this->Common->autoRedirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/MimeTypesController.php
+++ b/src/Controller/Admin/MimeTypesController.php
@@ -203,7 +203,7 @@ class MimeTypesController extends DataAppController {
 	 */
 	public function view($id = null) {
 		if (empty($id)) {
-			$this->Flash->error(__('record invalid'));
+			$this->Flash->error(__d('data', 'record invalid'));
 
 			return $this->Common->autoRedirect(['action' => 'index']);
 		}
@@ -227,12 +227,12 @@ class MimeTypesController extends DataAppController {
 			if ($this->MimeTypes->save($mimeType)) {
 				$id = $mimeType->id;
 				//$name = $this->request->data['name'];
-				$this->Flash->success(__('record add {0} saved', $id));
+				$this->Flash->success(__d('data', 'record add {0} saved', $id));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record add not saved'));
+			$this->Flash->error(__d('data', 'record add not saved'));
 		} else {
 			$this->request = $this->request->withData('active', true);
 		}
@@ -254,12 +254,12 @@ class MimeTypesController extends DataAppController {
 
 			if ($this->MimeTypes->save($mimeType)) {
 				//$name = $this->request->data['name'];
-				$this->Flash->success(__('record edit {0} saved', $id));
+				$this->Flash->success(__d('data', 'record edit {0} saved', $id));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record edit not saved'));
+			$this->Flash->error(__d('data', 'record edit not saved'));
 		}
 
 		$mimeTypeImages = $this->MimeTypes->MimeTypeImages->find('list');
@@ -276,18 +276,18 @@ class MimeTypesController extends DataAppController {
 
 		$mimeType = $this->MimeTypes->find('all', ...['fields' => ['id'], 'conditions' => ['MimeTypes.id' => $id]])->first();
 		if (!$mimeType) {
-			$this->Flash->error(__('record del not exists'));
+			$this->Flash->error(__d('data', 'record del not exists'));
 
 			return $this->Common->autoRedirect(['action' => 'index']);
 		}
 
 		if ($this->MimeTypes->delete($mimeType)) {
-			$this->Flash->success(__('record del {0} done', $id));
+			$this->Flash->success(__d('data', 'record del {0} done', $id));
 
 			return $this->Common->autoRedirect(['action' => 'index']);
 		}
 
-		$this->Flash->error(__('record del {0} not done exception', $id));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', $id));
 
 		return $this->Common->autoRedirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/PostalCodesController.php
+++ b/src/Controller/Admin/PostalCodesController.php
@@ -67,12 +67,12 @@ class PostalCodesController extends DataAppController {
 			$postalCode = $this->PostalCodes->patchEntity($postalCode, $this->request->getData());
 			if ($this->PostalCodes->save($postalCode)) {
 				$var = $postalCode['code'];
-				$this->Flash->success(__('record add {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record add {0} saved', h($var)));
 
 				return $this->Common->postRedirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 		}
 
 		$this->set(compact('postalCode'));
@@ -90,12 +90,12 @@ class PostalCodesController extends DataAppController {
 
 			if ($this->PostalCodes->save($postalCode)) {
 				$var = $postalCode['code'];
-				$this->Flash->success(__('record edit {0} saved', h($var)));
+				$this->Flash->success(__d('data', 'record edit {0} saved', h($var)));
 
 				return $this->Common->postRedirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('formContainsErrors'));
+			$this->Flash->error(__d('data', 'formContainsErrors'));
 		}
 
 		$this->set(compact('postalCode'));
@@ -112,11 +112,11 @@ class PostalCodesController extends DataAppController {
 		$var = $postalCode['code'];
 
 		if ($this->PostalCodes->delete($postalCode)) {
-			$this->Flash->success(__('record del {0} done', h($var)));
+			$this->Flash->success(__d('data', 'record del {0} done', h($var)));
 
 			return $this->redirect(['action' => 'index']);
 		}
-		$this->Flash->error(__('record del {0} not done exception', h($var)));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', h($var)));
 
 		return $this->Common->autoRedirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/StatesController.php
+++ b/src/Controller/Admin/StatesController.php
@@ -84,12 +84,12 @@ class StatesController extends DataAppController {
 			if ($this->States->save($state)) {
 				$id = $state->id;
 				$name = $this->request->getData('name');
-				$this->Flash->success(__('record add {0} saved', h($name)));
+				$this->Flash->success(__d('data', 'record add {0} saved', h($name)));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record add not saved'));
+			$this->Flash->error(__d('data', 'record add not saved'));
 		}
 
 		$countries = $this->States->Countries->find('list');
@@ -108,12 +108,12 @@ class StatesController extends DataAppController {
 
 			if ($this->States->save($state)) {
 				$name = $this->request->getData('name');
-				$this->Flash->success(__('record edit {0} saved', h($name)));
+				$this->Flash->success(__d('data', 'record edit {0} saved', h($name)));
 
 				return $this->redirect(['action' => 'index']);
 			}
 
-			$this->Flash->error(__('record edit not saved'));
+			$this->Flash->error(__d('data', 'record edit not saved'));
 		}
 
 		$countries = $this->States->Countries->find('list');
@@ -131,12 +131,12 @@ class StatesController extends DataAppController {
 
 		$name = $state['name'];
 		if ($this->States->delete($state)) {
-			$this->Flash->success(__('record del {0} done', h($name)));
+			$this->Flash->success(__d('data', 'record del {0} done', h($name)));
 
 			return $this->redirect(['action' => 'index']);
 		}
 
-		$this->Flash->error(__('record del {0} not done exception', $name));
+		$this->Flash->error(__d('data', 'record del {0} not done exception', $name));
 
 		return $this->redirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/TimezonesController.php
+++ b/src/Controller/Admin/TimezonesController.php
@@ -177,11 +177,11 @@ class TimezonesController extends AppController {
 		if ($this->request->is('post')) {
 			$timezone = $this->Timezones->patchEntity($timezone, $this->request->getData());
 			if ($this->Timezones->save($timezone)) {
-				$this->Flash->success(__('The timezone has been saved.'));
+				$this->Flash->success(__d('data', 'The timezone has been saved.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('The timezone could not be saved. Please, try again.'));
+			$this->Flash->error(__d('data', 'The timezone could not be saved. Please, try again.'));
 		}
 		$this->set(compact('timezone'));
 	}
@@ -195,11 +195,11 @@ class TimezonesController extends AppController {
 		if ($this->request->is(['patch', 'post', 'put'])) {
 			$timezone = $this->Timezones->patchEntity($timezone, $this->request->getData());
 			if ($this->Timezones->save($timezone)) {
-				$this->Flash->success(__('The timezone has been saved.'));
+				$this->Flash->success(__d('data', 'The timezone has been saved.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('The timezone could not be saved. Please, try again.'));
+			$this->Flash->error(__d('data', 'The timezone could not be saved. Please, try again.'));
 		}
 		$this->set(compact('timezone'));
 	}
@@ -212,9 +212,9 @@ class TimezonesController extends AppController {
 		$this->request->allowMethod(['post', 'delete']);
 		$timezone = $this->Timezones->get($id);
 		if ($this->Timezones->delete($timezone)) {
-			$this->Flash->success(__('The timezone has been deleted.'));
+			$this->Flash->success(__d('data', 'The timezone has been deleted.'));
 		} else {
-			$this->Flash->error(__('The timezone could not be deleted. Please, try again.'));
+			$this->Flash->error(__d('data', 'The timezone could not be deleted. Please, try again.'));
 		}
 
 		return $this->redirect(['action' => 'index']);

--- a/src/Model/Entity/Address.php
+++ b/src/Model/Entity/Address.php
@@ -49,8 +49,8 @@ class Address extends Entity {
 	 */
 	public static function addressTypes($value = null) {
 		$options = [
-			static::TYPE_MAIN => __('Main Residence'),
-			static::TYPE_OTHER => __('Other'),
+			static::TYPE_MAIN => __d('data', 'Main Residence'),
+			static::TYPE_OTHER => __d('data', 'Other'),
 		];
 
 		return parent::enum($value, $options);

--- a/src/Model/Entity/Continent.php
+++ b/src/Model/Entity/Continent.php
@@ -40,8 +40,8 @@ class Continent extends Entity {
 	 */
 	public static function directions($value = null) {
 		$options = [
-			static::STATUS_INACTIVE => __('Inactive'),
-			static::STATUS_ACTIVE => __('Active'),
+			static::STATUS_INACTIVE => __d('data', 'Inactive'),
+			static::STATUS_ACTIVE => __d('data', 'Active'),
 		];
 
 		return parent::enum($value, $options);

--- a/src/Model/Table/AddressesTable.php
+++ b/src/Model/Table/AddressesTable.php
@@ -57,7 +57,7 @@ class AddressesTable extends Table {
 			->allowEmptyString('state_id')
 			->add('state_id', 'fitsToCountry', [
 				'rule' => 'fitsToCountry',
-				'message' => __('The province seems not be fit to the chosen country'),
+				'message' => __d('data', 'The province seems not be fit to the chosen country'),
 				'provider' => 'table',
 			]);
 
@@ -70,7 +70,7 @@ class AddressesTable extends Table {
 			->allowEmptyString('address_type_id')
 			->add('address_type_id', 'primaryUnique', [
 				'rule' => 'primaryUnique',
-				'message' => __('Only one address can be marked as "Main Residence", please choose another type'),
+				'message' => __d('data', 'Only one address can be marked as "Main Residence", please choose another type'),
 				'last' => true,
 				'provider' => 'table',
 			]);
@@ -80,7 +80,7 @@ class AddressesTable extends Table {
 			->allowEmptyString('postal_code')
 			->add('postal_code', 'correspondsWithCountry', [
 				'rule' => 'correspondsWithCountry',
-				'message' => __('The zip code seems not to have the correct length'),
+				'message' => __d('data', 'The zip code seems not to have the correct length'),
 				'provider' => 'table',
 			]);
 
@@ -97,16 +97,16 @@ class AddressesTable extends Table {
 			->allowEmptyString('formatted_address')
 			->add('formatted_address', 'validateUnique', [
 				'rule' => ['validateUnique', ['scope' => ['foreign_id', 'model']]],
-				'message' => __('valErrRecordNameExists'),
+				'message' => __d('data', 'valErrRecordNameExists'),
 				'provider' => 'table',
 			]);
 
 		$validator
-			->decimal('lat', 6, __('not a valid geografic number for latitude'))
+			->decimal('lat', 6, __d('data', 'not a valid geografic number for latitude'))
 			->allowEmptyString('lat');
 
 		$validator
-			->decimal('lng', 6, __('not a valid geografic number for longitude'))
+			->decimal('lng', 6, __d('data', 'not a valid geografic number for longitude'))
 			->allowEmptyString('lng');
 
 		return $validator;

--- a/src/Model/Table/DistrictsTable.php
+++ b/src/Model/Table/DistrictsTable.php
@@ -28,11 +28,11 @@ class DistrictsTable extends Table {
 	public function validationDefault(Validator $validator): Validator {
 		$validator
 			->scalar('name')
-			->notEmptyString('name', __('valErrMandatoryField'));
+			->notEmptyString('name', __d('data', 'valErrMandatoryField'));
 
 		$validator
 			->integer('city_id')
-			->notEmptyString('city_id', __('valErrMandatoryField'));
+			->notEmptyString('city_id', __d('data', 'valErrMandatoryField'));
 
 		return $validator;
 	}

--- a/src/Model/Table/LocationsTable.php
+++ b/src/Model/Table/LocationsTable.php
@@ -34,16 +34,16 @@ class LocationsTable extends Table {
 	public function validationDefault(Validator $validator): Validator {
 		$validator
 			->scalar('name')
-			->notEmptyString('name', __('valErrMandatoryField'))
+			->notEmptyString('name', __d('data', 'valErrMandatoryField'))
 			->add('name', 'unique', [
 				'rule' => ['validateUnique', ['scope' => ['country_id']]],
-				'message' => __('valErrRecordNameExists'),
+				'message' => __d('data', 'valErrRecordNameExists'),
 				'provider' => 'table',
 			]);
 
 		$validator
 			->integer('country_id')
-			->notEmptyString('country_id', __('valErrMandatoryField'));
+			->notEmptyString('country_id', __d('data', 'valErrMandatoryField'));
 
 		return $validator;
 	}
@@ -70,7 +70,7 @@ class LocationsTable extends Table {
 	 * @return \Cake\Datasource\EntityInterface|false
 	 */
 	public function getLocation($locationName, $countryId = null) {
-		$country = $countryId !== null ? ', ' . $countryId : __('Germany'); ////Country::addressList($countryId)
+		$country = $countryId !== null ? ', ' . $countryId : __d('data', 'Germany'); ////Country::addressList($countryId)
 		$countryId = $countryId ?? 1;
 
 		if (is_numeric($locationName) && strlen($locationName) < 5) { //Country::zipCodeLength($countryId)

--- a/src/Model/Table/MimeTypeImagesTable.php
+++ b/src/Model/Table/MimeTypeImagesTable.php
@@ -203,9 +203,9 @@ class MimeTypeImagesTable extends Table {
 	 */
 	public static function extensions($value = null) {
 		$options = [
-			'gif' => __('GIF (*.gif)'),
-			'png' => __('PNG (*.png)'),
-			'jpg' => __('JPG (*.jpg)'),
+			'gif' => __d('data', 'GIF (*.gif)'),
+			'png' => __d('data', 'PNG (*.png)'),
+			'jpg' => __d('data', 'JPG (*.jpg)'),
 		];
 
 		if ($value !== null) {

--- a/src/Model/Table/MimeTypesTable.php
+++ b/src/Model/Table/MimeTypesTable.php
@@ -174,7 +174,7 @@ class MimeTypesTable extends Table {
 		$email->setTo(Configure::read('Config.adminEmail'), Configure::read('Config.adminEmailname'));
 		$email->setReplyTo(Configure::read('Config.adminEmail'), Configure::read('Config.adminEmailname'));
 
-		$email->setSubject(Configure::read('Config.page_name') . ' - ' . __('MimeType'));
+		$email->setSubject(Configure::read('Config.page_name') . ' - ' . __d('data', 'MimeType'));
 		$email->viewBuilder()->setTemplate('simple_email');
 
 		$text = 'MimeType added: ' . $ext . '';

--- a/templates/Addresses/index.php
+++ b/templates/Addresses/index.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Addresses');?></h2>
+<h2><?php echo __d('data', 'Addresses');?></h2>
 
 <table class="table">
 <tr>
@@ -22,7 +22,7 @@
 	<th><?php echo $this->Paginator->sort('lng');?></th>
 	<th><?php echo $this->Paginator->sort('last_used');?></th>
 	<th><?php echo $this->Paginator->sort('formatted_address');?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 $i = 0;
@@ -94,7 +94,7 @@ foreach ($addresses as $address):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add {0}', __('Address')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add {0}', __d('data', 'Address')), ['action' => 'add']); ?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Addresses/view.php
+++ b/templates/Addresses/view.php
@@ -5,69 +5,69 @@
  */
 ?>
 <div class="page view">
-<h2><?php echo __('Address');?></h2>
+<h2><?php echo __d('data', 'Address');?></h2>
 	<dl>
-		<dt><?php echo __('User'); ?></dt>
+		<dt><?php echo __d('data', 'User'); ?></dt>
 		<dd>
 			<?php echo $this->Html->link($address->user['id'], ['controller' => 'Users', 'action' => 'view', $address->user['id']]); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Model'); ?></dt>
+		<dt><?php echo __d('data', 'Model'); ?></dt>
 		<dd>
 			<?php echo h($address['model']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Country'); ?></dt>
+		<dt><?php echo __d('data', 'Country'); ?></dt>
 		<dd>
 			<?php echo $this->Html->link($address->country->name, ['controller' => 'Countries', 'action' => 'view', $address->country->id]); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Country Province'); ?></dt>
+		<dt><?php echo __d('data', 'Country Province'); ?></dt>
 		<dd>
 			<?php echo $this->Html->link($address->state['name'], ['controller' => 'States', 'action' => 'view', $address->state['id']]); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('First Name'); ?></dt>
+		<dt><?php echo __d('data', 'First Name'); ?></dt>
 		<dd>
 			<?php echo h($address['first_name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Last Name'); ?></dt>
+		<dt><?php echo __d('data', 'Last Name'); ?></dt>
 		<dd>
 			<?php echo h($address['last_name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Street'); ?></dt>
+		<dt><?php echo __d('data', 'Street'); ?></dt>
 		<dd>
 			<?php echo h($address['street']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Postal Code'); ?></dt>
+		<dt><?php echo __d('data', 'Postal Code'); ?></dt>
 		<dd>
 			<?php echo h($address['postal_code']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('City'); ?></dt>
+		<dt><?php echo __d('data', 'City'); ?></dt>
 		<dd>
 			<?php echo h($address['city']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Lat'); ?></dt>
+		<dt><?php echo __d('data', 'Lat'); ?></dt>
 		<dd>
 			<?php echo h($address->lat); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Lng'); ?></dt>
+		<dt><?php echo __d('data', 'Lng'); ?></dt>
 		<dd>
 			<?php echo h($address->lng); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Last Used'); ?></dt>
+		<dt><?php echo __d('data', 'Last Used'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($address['last_used']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Formatted Address'); ?></dt>
+		<dt><?php echo __d('data', 'Formatted Address'); ?></dt>
 		<dd>
 			<?php echo h($address['formatted_address']); ?>
 			&nbsp;
@@ -79,15 +79,15 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit {0}', __('Address')), ['action' => 'edit', $address['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Address')), ['action' => 'delete', $address['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit {0}', __d('data', 'Address')), ['action' => 'edit', $address['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete {0}', __d('data', 'Address')), ['action' => 'delete', $address['id']], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $address['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $address['id']),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Addresses')), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Addresses')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Addresses/add.php
+++ b/templates/Admin/Addresses/add.php
@@ -7,16 +7,16 @@
 use Cake\Core\Configure;
 
 ?>
-<h2><?php echo __('Add {0}', __('Address')); ?></h2>
+<h2><?php echo __d('data', 'Add {0}', __d('data', 'Address')); ?></h2>
 
 <div class="page form">
 <?php echo $this->Form->create($address);?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('Address')); ?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'Address')); ?></legend>
 	<?php
-		echo $this->Form->control('country_id', ['empty' => [0 => ' - [ ' . __('noSelection') . ' ] - ']]);
+		echo $this->Form->control('country_id', ['empty' => [0 => ' - [ ' . __d('data', 'noSelection') . ' ] - ']]);
 	if (Configure::read('Data.Address.State')) {
-		echo $this->Form->control('country_province_id', ['empty' => [0 => ' - [ ' . __('noSelection') . ' ] - ']]);
+		echo $this->Form->control('country_province_id', ['empty' => [0 => ' - [ ' . __d('data', 'noSelection') . ' ] - ']]);
 	}
 		echo $this->Form->control('first_name');
 		echo $this->Form->control('last_name');
@@ -26,19 +26,19 @@ use Cake\Core\Configure;
 	?>
 	</fieldset>
 	<fieldset>
-		<legend><?php echo __('Relations'); ?></legend>
+		<legend><?php echo __d('data', 'Relations'); ?></legend>
 	<?php
 		echo $this->Form->control('model');
-		echo $this->Form->control('foreign_id', ['type' => 'text', 'empty' => [0 => ' - [ ' . __('noSelection') . ' ] - ']]);
+		echo $this->Form->control('foreign_id', ['type' => 'text', 'empty' => [0 => ' - [ ' . __d('data', 'noSelection') . ' ] - ']]);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Addresses')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Addresses')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/Addresses/edit.php
+++ b/templates/Admin/Addresses/edit.php
@@ -7,17 +7,17 @@
 use Cake\Core\Configure;
 
 ?>
-<h2><?php echo __('Edit {0}', __('Address')); ?></h2>
+<h2><?php echo __d('data', 'Edit {0}', __d('data', 'Address')); ?></h2>
 
 <div class="page form">
 <?php echo $this->Form->create($address);?>
 	<fieldset>
-		<legend><?php echo __('Edit {0}', __('Address')); ?></legend>
+		<legend><?php echo __d('data', 'Edit {0}', __d('data', 'Address')); ?></legend>
 	<?php
 		//echo $this->Form->control('id');
-		echo $this->Form->control('country_id', ['empty' => ' - [ ' . __('noSelection') . ' ] - ']);
+		echo $this->Form->control('country_id', ['empty' => ' - [ ' . __d('data', 'noSelection') . ' ] - ']);
 	if (Configure::read('Data.Address.State')) {
-		echo $this->Form->control('state_id', ['id' => 'country-states', 'empty' => ' - [ ' . __('noSelection') . ' ] - ']);
+		echo $this->Form->control('state_id', ['id' => 'country-states', 'empty' => ' - [ ' . __d('data', 'noSelection') . ' ] - ']);
 	}
 		echo $this->Form->control('first_name');
 		echo $this->Form->control('last_name');
@@ -27,27 +27,27 @@ use Cake\Core\Configure;
 	?>
 	</fieldset>
 	<fieldset>
-		<legend><?php echo __('Relations'); ?></legend>
+		<legend><?php echo __d('data', 'Relations'); ?></legend>
 	<?php
 		echo $this->Form->control('model');
-		echo $this->Form->control('foreign_id', ['type' => 'text', 'empty' => [0 => ' - [ ' . __('noSelection') . ' ] - ']]);
+		echo $this->Form->control('foreign_id', ['type' => 'text', 'empty' => [0 => ' - [ ' . __d('data', 'noSelection') . ' ] - ']]);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('Address.id')], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $this->Form->getSourceValue('Address.id')], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('Address.id')),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $this->Form->getSourceValue('Address.id')),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Addresses')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Addresses')), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Addresses/index.php
+++ b/templates/Admin/Addresses/index.php
@@ -6,7 +6,7 @@
 use Cake\Core\Configure;
 ?>
 <div class="page index">
-<h2><?php echo __('Addresses');?></h2>
+<h2><?php echo __d('data', 'Addresses');?></h2>
 
 <table class="table">
 <tr>
@@ -19,10 +19,10 @@ use Cake\Core\Configure;
 	<th><?php echo $this->Paginator->sort('street');?></th>
 	<th><?php echo $this->Paginator->sort('postal_code');?></th>
 	<th><?php echo $this->Paginator->sort('city');?></th>
-	<th><?php echo __('Coordinates');?></th>
+	<th><?php echo __d('data', 'Coordinates');?></th>
 	<th><?php echo $this->Paginator->sort('last_used');?></th>
 	<th><?php echo $this->Paginator->sort('formatted_address');?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 /** @var \Data\Model\Entity\Address[] $addresses */
@@ -69,12 +69,12 @@ foreach ($addresses as $address):
 
 					if (Configure::read('GoogleMap.key')) {
 						$mapMarkers = $this->GoogleMap->staticMarkers($markers);
-						echo $this->Html->link($this->Icon->render('view', ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $address->lat . ',' . $address->lng, 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 12]), ['id' => 'googleMap', 'class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
+						echo $this->Html->link($this->Icon->render('view', ['title' => __d('data', 'Show')]), $this->GoogleMap->staticMapUrl(['center' => $address->lat . ',' . $address->lng, 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 12]), ['id' => 'googleMap', 'class' => 'internal zoom-image highslideImage', 'title' => __d('data', 'click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 					} else {
 						$options = [
 							'to' => $address->lat . ',' . $address->lng,
 						];
-						echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
+						echo $this->Html->link($this->Icon->render('view', [], ['title' => __d('data', 'Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __d('data', 'click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 					}
 				}
 			 ?>
@@ -110,7 +110,7 @@ foreach ($addresses as $address):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add {0}', __('Address')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add {0}', __d('data', 'Address')), ['action' => 'add']); ?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Addresses/view.php
+++ b/templates/Admin/Addresses/view.php
@@ -5,68 +5,68 @@
  */
 ?>
 <div class="page view">
-<h2><?php echo __('Address');?></h2>
+<h2><?php echo __d('data', 'Address');?></h2>
 	<dl>
 
-		<dt><?php echo __('Country'); ?></dt>
+		<dt><?php echo __d('data', 'Country'); ?></dt>
 		<dd>
 			<?php echo $this->Html->link($address->country->name, ['controller' => 'Countries', 'action' => 'view', $address->country->id]); ?>
 			&nbsp;
 		</dd>
 <?php if (Configure::read('Data.Address.State')) { ?>
-		<dt><?php echo __('Country Province'); ?></dt>
+		<dt><?php echo __d('data', 'Country Province'); ?></dt>
 		<dd>
 			<?php echo $this->Html->link($address->state['name'], ['controller' => 'States', 'action' => 'view', $address->state['id']]); ?>
 			&nbsp;
 		</dd>
 <?php } ?>
-		<dt><?php echo __('First Name'); ?></dt>
+		<dt><?php echo __d('data', 'First Name'); ?></dt>
 		<dd>
 			<?php echo h($address['first_name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Last Name'); ?></dt>
+		<dt><?php echo __d('data', 'Last Name'); ?></dt>
 		<dd>
 			<?php echo h($address['last_name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Street'); ?></dt>
+		<dt><?php echo __d('data', 'Street'); ?></dt>
 		<dd>
 			<?php echo h($address['street']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Postal Code'); ?></dt>
+		<dt><?php echo __d('data', 'Postal Code'); ?></dt>
 		<dd>
 			<?php echo h($address['postal_code']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('City'); ?></dt>
+		<dt><?php echo __d('data', 'City'); ?></dt>
 		<dd>
 			<?php echo h($address['city']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Lat'); ?></dt>
+		<dt><?php echo __d('data', 'Lat'); ?></dt>
 		<dd>
 			<?php echo h($address->lat); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Lng'); ?></dt>
+		<dt><?php echo __d('data', 'Lng'); ?></dt>
 		<dd>
 			<?php echo h($address->lng); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Last Used'); ?></dt>
+		<dt><?php echo __d('data', 'Last Used'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($address['last_used']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Formatted Address'); ?></dt>
+		<dt><?php echo __d('data', 'Formatted Address'); ?></dt>
 		<dd>
 			<?php echo h($address['formatted_address']); ?>
 			&nbsp;
 		</dd>
 <?php if (Configure::read('Data.Address.debug')) { ?>
-		<dt><?php echo __('Debug'); ?></dt>
+		<dt><?php echo __d('data', 'Debug'); ?></dt>
 		<dd>
 			<?php echo pre($address['geocoder_result']); ?>
 			&nbsp;
@@ -79,16 +79,16 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit {0}', __('Address')), ['action' => 'edit', $address['id']]); ?> </li>
-		<li><?php echo $this->Html->link(__('Mark as {0}', __('Used')), ['action' => 'mark_as_used', $address['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Address')), ['action' => 'delete', $address['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit {0}', __d('data', 'Address')), ['action' => 'edit', $address['id']]); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'Mark as {0}', __d('data', 'Used')), ['action' => 'mark_as_used', $address['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete {0}', __d('data', 'Address')), ['action' => 'delete', $address['id']], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $address['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $address['id']),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Addresses')), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Addresses')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Cities/add.php
+++ b/templates/Admin/Cities/add.php
@@ -8,11 +8,11 @@ use Cake\Core\Configure;
 
 ?>
 <div class="page form">
-<h2><?php echo __('Add {0}', __('City')); ?></h2>
+<h2><?php echo __d('data', 'Add {0}', __d('data', 'City')); ?></h2>
 
 <?php echo $this->Form->create($city);?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('City')); ?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'City')); ?></legend>
 	<?php
 		echo $this->Form->control('country_id');
 		echo $this->Form->control('official_key', ['type' => 'text']);
@@ -30,12 +30,12 @@ use Cake\Core\Configure;
 		echo $this->Form->control('description');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <div class="actions">
 	<ul>
 
-		<li><?php echo $this->Html->link(__('List {0}', __('Cities')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Cities')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/Cities/edit.php
+++ b/templates/Admin/Cities/edit.php
@@ -8,11 +8,11 @@ use Cake\Core\Configure;
 
 ?>
 <div class="page form">
-<h2><?php echo __('Edit {0}', __('City')); ?></h2>
+<h2><?php echo __d('data', 'Edit {0}', __d('data', 'City')); ?></h2>
 
 <?php echo $this->Form->create($city);?>
 	<fieldset>
-		<legend><?php echo __('Edit {0}', __('City')); ?></legend>
+		<legend><?php echo __d('data', 'Edit {0}', __d('data', 'City')); ?></legend>
 	<?php
 		//echo $this->Form->control('id');
 		echo $this->Form->control('country_id');
@@ -32,20 +32,20 @@ use Cake\Core\Configure;
 
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <div class="actions">
 	<ul>
 
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('City.id')], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $this->Form->getSourceValue('City.id')], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('City.id')),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $this->Form->getSourceValue('City.id')),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Cities')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Cities')), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Cities/index.php
+++ b/templates/Admin/Cities/index.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div class="page index">
-	<h2><?php echo __('Cities');?></h2>
+	<h2><?php echo __d('data', 'Cities');?></h2>
 
 	<table class="table">
 		<tr>
@@ -16,7 +16,7 @@
 		<th><?php echo ('Coordinates');?></th>
 		<th><?php echo $this->Paginator->sort('postal_code_unique');?></th>
 		<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-		<th class="actions"><?php echo __('Actions');?></th>
+		<th class="actions"><?php echo __d('data', 'Actions');?></th>
 	</tr>
 <?php
 foreach ($cities as $city) { ?>
@@ -68,7 +68,7 @@ foreach ($cities as $city) { ?>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('New {0}', __('City')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'New {0}', __d('data', 'City')), ['action' => 'add']); ?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Cities/view.php
+++ b/templates/Admin/Cities/view.php
@@ -5,57 +5,57 @@
  */
 ?>
 <div class="page view">
-<h2><?php  echo __('City');?></h2>
+<h2><?php  echo __d('data', 'City');?></h2>
 	<dl>
-		<dt><?php echo __('Country Id'); ?></dt>
+		<dt><?php echo __d('data', 'Country Id'); ?></dt>
 		<dd>
 			<?php echo h($city['country_id']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Official Id'); ?></dt>
+		<dt><?php echo __d('data', 'Official Id'); ?></dt>
 		<dd>
 			<?php echo h($city['official_key']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('County Id'); ?></dt>
+		<dt><?php echo __d('data', 'County Id'); ?></dt>
 		<dd>
 			<?php echo h($city['county_id']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Name'); ?></dt>
+		<dt><?php echo __d('data', 'Name'); ?></dt>
 		<dd>
 			<?php echo h($city['name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Citizens'); ?></dt>
+		<dt><?php echo __d('data', 'Citizens'); ?></dt>
 		<dd>
 			<?php echo h($city['citizens']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Postal Code'); ?></dt>
+		<dt><?php echo __d('data', 'Postal Code'); ?></dt>
 		<dd>
 			<?php echo h($city['postal_code']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Lat'); ?></dt>
+		<dt><?php echo __d('data', 'Lat'); ?></dt>
 		<td>
 			<?php echo $this->Number->format($city['lat']); ?>
 		</td>
-		<dt><?php echo __('Lng'); ?></dt>
+		<dt><?php echo __d('data', 'Lng'); ?></dt>
 		<td>
 			<?php echo $this->Number->format($city['lng']); ?>
 		</td>
-		<dt><?php echo __('Description'); ?></dt>
+		<dt><?php echo __d('data', 'Description'); ?></dt>
 		<dd>
 			<?php echo nl2br(h($city['description'])); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Postal Code Unique'); ?></dt>
+		<dt><?php echo __d('data', 'Postal Code Unique'); ?></dt>
 		<dd>
 			<?php echo $this->Format->yesNo($city['postal_code_unique']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Modified'); ?></dt>
+		<dt><?php echo __d('data', 'Modified'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($city['modified']); ?>
 			&nbsp;
@@ -65,15 +65,15 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit {0}', __('City')), ['action' => 'edit', $city['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete {0}', __('City')), ['action' => 'delete', $city['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit {0}', __d('data', 'City')), ['action' => 'edit', $city['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete {0}', __d('data', 'City')), ['action' => 'delete', $city['id']], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $city['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $city['id']),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Cities')), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Cities')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Continents/add.php
+++ b/templates/Admin/Continents/add.php
@@ -4,12 +4,12 @@
  * @var \Data\Model\Entity\Continent $continent
  */
 ?>
-<h2><?php echo __('Add {0}', __('Continent')); ?></h2>
+<h2><?php echo __d('data', 'Add {0}', __d('data', 'Continent')); ?></h2>
 
 <div class="page form">
 <?php echo $this->Form->create($continent);?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('Continent')); ?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'Continent')); ?></legend>
 	<?php
 		echo $this->Form->control('name');
 		//echo $this->Form->control('ori_name');
@@ -20,13 +20,13 @@
 		//echo $this->Form->control('status');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Continents')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Continents')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/Continents/edit.php
+++ b/templates/Admin/Continents/edit.php
@@ -4,12 +4,12 @@
  * @var \Data\Model\Entity\Continent $continent
  */
 ?>
-<h2><?php echo __('Edit {0}', __('Continent')); ?></h2>
+<h2><?php echo __d('data', 'Edit {0}', __d('data', 'Continent')); ?></h2>
 
 <div class="page form">
 <?php echo $this->Form->create($continent);?>
 	<fieldset>
-		<legend><?php echo __('Edit {0}', __('Continent')); ?></legend>
+		<legend><?php echo __d('data', 'Edit {0}', __d('data', 'Continent')); ?></legend>
 	<?php
 		echo $this->Form->control('name');
 		//echo $this->Form->control('ori_name');
@@ -19,21 +19,21 @@
 		//echo $this->Form->control('status');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('Continent.id')], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $this->Form->getSourceValue('Continent.id')], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('Continent.id')),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $this->Form->getSourceValue('Continent.id')),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Continents')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Continents')), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Continents/index.php
+++ b/templates/Admin/Continents/index.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Continents');?></h2>
+<h2><?php echo __d('data', 'Continents');?></h2>
 
 <table class="table">
 <tr>
@@ -13,7 +13,7 @@
 	<th><?php echo $this->Paginator->sort('code');?></th>
 	<th><?php echo $this->Paginator->sort('parent_id');?></th>
 	<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 foreach ($continents as $continent):
@@ -56,8 +56,8 @@ foreach ($continents as $continent):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add {0}', __('Continent')), ['action' => 'add']); ?></li>
-		<li><?php echo $this->Html->link(__('Tree'), ['action' => 'tree']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add {0}', __d('data', 'Continent')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Tree'), ['action' => 'tree']); ?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Continents/tree.php
+++ b/templates/Admin/Continents/tree.php
@@ -7,12 +7,12 @@
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
 	<ul class="side-nav nav nav-pills flex-column">
-		<li class="nav-item heading"><?= __('Actions') ?></li>
+		<li class="nav-item heading"><?= __d('data', 'Actions') ?></li>
 	</ul>
 </nav>
 <div class="cities index content large-9 medium-8 columns col-sm-8 col-12">
 
-	<h1><?= __('Tree') ?></h1>
+	<h1><?= __d('data', 'Tree') ?></h1>
 
 	<div class="tree">
 		<?php

--- a/templates/Admin/Continents/view.php
+++ b/templates/Admin/Continents/view.php
@@ -5,33 +5,33 @@
  */
 ?>
 <div class="page view">
-<h1><?php echo __('Continent');?></h1>
+<h1><?php echo __d('data', 'Continent');?></h1>
 
 	<h2><?php echo h($continent['name']); ?></h2>
 	<dl>
 
-		<dt><?php echo __('Ori Name'); ?></dt>
+		<dt><?php echo __d('data', 'Ori Name'); ?></dt>
 		<dd>
 			<?php echo h($continent['ori_name']); ?>
 			&nbsp;
 		</dd>
 
-		<dt><?php echo __('Code'); ?></dt>
+		<dt><?php echo __d('data', 'Code'); ?></dt>
 		<dd>
 			<?php echo h($continent->code); ?>
 		</dd>
 
-		<dt><?php echo __('Parent Continent'); ?></dt>
+		<dt><?php echo __d('data', 'Parent Continent'); ?></dt>
 		<dd>
 			<?php echo $continent->parent_continent ? $this->Html->link($continent->parent_continent->name, ['controller' => 'Continents', 'action' => 'view', $continent->parent_continent['id']]) : ''; ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Status'); ?></dt>
+		<dt><?php echo __d('data', 'Status'); ?></dt>
 		<dd>
 			<?php echo h($continent['status']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Modified'); ?></dt>
+		<dt><?php echo __d('data', 'Modified'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($continent['modified']); ?>
 			&nbsp;
@@ -43,12 +43,12 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit {0}', __('Continent')), ['action' => 'edit', $continent['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Continent')), ['action' => 'delete', $continent['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit {0}', __d('data', 'Continent')), ['action' => 'edit', $continent['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete {0}', __d('data', 'Continent')), ['action' => 'delete', $continent['id']], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $continent['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $continent['id']),
 			],
 		]); ?> </li>
 	</ul>

--- a/templates/Admin/Countries/add.php
+++ b/templates/Admin/Countries/add.php
@@ -7,7 +7,7 @@
 <div class="page form">
 <?php echo $this->Form->create($country);?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('Country'));?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'Country'));?></legend>
 	<?php
 		echo $this->Form->control('name');
 		echo $this->Form->control('ori_name');
@@ -22,13 +22,13 @@
 		echo $this->Form->control('status', ['type' => 'checkbox', 'label' => 'Aktiv']);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Countries')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/Countries/edit.php
+++ b/templates/Admin/Countries/edit.php
@@ -10,7 +10,7 @@ use Cake\Core\Configure;
 <div class="page form">
 <?php echo $this->Form->create($country);?>
 	<fieldset>
-		<legend><?php echo __('Edit {0}', __('Country'));?></legend>
+		<legend><?php echo __d('data', 'Edit {0}', __d('data', 'Country'));?></legend>
 	<?php
 		echo $this->Form->control('name');
 		echo $this->Form->control('ori_name');
@@ -32,22 +32,22 @@ use Cake\Core\Configure;
 		echo $this->Form->control('status', ['type' => 'checkbox', 'label' => 'Aktiv']);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $country->id], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $country->id], [
 			'escapeTitle' => false,
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $country->id),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $country->id),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Countries')), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Countries/index.php
+++ b/templates/Admin/Countries/index.php
@@ -18,14 +18,14 @@ use Cake\Core\Plugin;
 <?php $this->Html->script('highslide/highslide_config'); ?>
 
 <div class="page index">
-<h2><?php echo __('Countries');?></h2>
+<h2><?php echo __d('data', 'Countries');?></h2>
 
 <?php if (Plugin::isLoaded('Search')) { ?>
 <div class="search-box">
 <?php
 echo $this->Form->create(null, ['valueSources' => 'query']);
-echo $this->Form->control('search', ['placeholder' => __('wildcardSearch {0} and {1}', '*', '?')]);
-echo $this->Form->button(__('Search'), []);
+echo $this->Form->control('search', ['placeholder' => __d('data', 'wildcardSearch {0} and {1}', '*', '?')]);
+echo $this->Form->button(__d('data', 'Search'), []);
 echo $this->Form->end();
 if ($this->Search->isSearch()) {
 	echo $this->Search->resetLink(null, ['class' => 'btn btn-secondary']);
@@ -41,10 +41,10 @@ if ($this->Search->isSearch()) {
 	<th><?php echo $this->Paginator->sort('ori_name');?></th>
 	<th><?php echo $this->Paginator->sort('iso2');?></th>
 	<th><?php echo $this->Paginator->sort('iso3');?></th>
-	<th><?php echo __('Coordinates');?></th>
+	<th><?php echo __d('data', 'Coordinates');?></th>
 	<th><?php echo $this->Paginator->sort('sort');?></th>
 	<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 foreach ($countries as $country):
@@ -72,7 +72,7 @@ foreach ($countries as $country):
 			if ((int)$country['lat'] != 0 || (int)$country['lng'] != 0) {
 				$coordinates = $country['lat'] . ',' . $country['lng'];
 			}
-			echo $this->Format->yesNo((int)!empty($coordinates), ['onTitle' => $coordinates, 'offTitle' => __('n/a')]) . ' ';
+			echo $this->Format->yesNo((int)!empty($coordinates), ['onTitle' => $coordinates, 'offTitle' => __d('data', 'n/a')]) . ' ';
 
 			if (!empty($coordinates)) {
 				$markers = [];
@@ -80,12 +80,12 @@ foreach ($countries as $country):
 
 				if (Configure::read('GoogleMap.key')) {
 					$mapMarkers = $this->GoogleMap->staticMarkers($markers);
-					echo ' ' . $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $country['lat'] . ',' . $country['lng'], 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 3]), ['class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
+					echo ' ' . $this->Html->link($this->Icon->render('view', [], ['title' => __d('data', 'Show')]), $this->GoogleMap->staticMapUrl(['center' => $country['lat'] . ',' . $country['lng'], 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 3]), ['class' => 'internal zoom-image highslideImage', 'title' => __d('data', 'click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 				} else {
 					$options = [
 						'to' => $country->lat . ',' . $country->lng,
 					];
-					echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
+					echo $this->Html->link($this->Icon->render('view', [], ['title' => __d('data', 'Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __d('data', 'click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 				}
 			}
 
@@ -104,14 +104,14 @@ foreach ($countries as $country):
 			<?php echo $this->Html->link($this->Icon->render('view'), ['action'=>'view', $country->id], ['escapeTitle' => false]); ?>
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $country->id], ['escapeTitle' => false]); ?>
 
-			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __('Koordinaten updaten')]), ['action' => 'update_coordinates', $country->id], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __d('data', 'Koordinaten updaten')]), ['action' => 'update_coordinates', $country->id], ['escapeTitle' => false]); ?>
 
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $country->id], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $country->id),
+					'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $country->id),
 				],
 			]); ?>
 		</td>
@@ -125,16 +125,16 @@ foreach ($countries as $country):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add {0}', __('Country')), ['action' => 'add']); ?></li>
-		<li><?php echo $this->Html->link(__('Sync'), ['action' => 'sync']); ?></li>
-		<li><?php echo $this->Html->link(__('Icons'), ['action' => 'icons']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add {0}', __d('data', 'Country')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Sync'), ['action' => 'sync']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Icons'), ['action' => 'icons']); ?></li>
 	</ul>
 </div>
 
 <br/>
 Hinweis:
 <ul>
-<li><?__('countryCodeExplanation')?></li>
+<li><?__d('data', 'countryCodeExplanation')?></li>
 </ul>
 <?= $this->element('Data.csp_confirm') ?>
 

--- a/templates/Admin/Countries/sync.php
+++ b/templates/Admin/Countries/sync.php
@@ -12,7 +12,7 @@
 
 	<?php echo $this->Form->create(); ?>
 	<fieldset>
-		<legend><?php echo __('Sync Countries');?></legend>
+		<legend><?php echo __d('data', 'Sync Countries');?></legend>
 
 		<?php
 		foreach ($diff as $action => $rows) {
@@ -37,6 +37,6 @@
 		}
 	?>
 	</fieldset>
-	<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+	<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 
 </div>

--- a/templates/Admin/Countries/view.php
+++ b/templates/Admin/Countries/view.php
@@ -5,33 +5,33 @@
  */
 ?>
 <div class="page view">
-<h2><?php echo __('Country');?></h2>
+<h2><?php echo __d('data', 'Country');?></h2>
 	<dl>
-		<dt><?php echo __('Name'); ?></dt>
+		<dt><?php echo __d('data', 'Name'); ?></dt>
 		<dd>
 			<?php echo h($country->name); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Ori Name'); ?></dt>
+		<dt><?php echo __d('data', 'Ori Name'); ?></dt>
 		<dd>
 			<?php echo h($country['ori_name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Iso2'); ?></dt>
+		<dt><?php echo __d('data', 'Iso2'); ?></dt>
 		<dd>
 			<?php echo h($country['iso2']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Iso3'); ?></dt>
+		<dt><?php echo __d('data', 'Iso3'); ?></dt>
 		<dd>
 			<?php echo h($country['iso3']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Phone Code'); ?></dt>
+		<dt><?php echo __d('data', 'Phone Code'); ?></dt>
 		<dd>
 			<?php echo ($country['phone_code'] ? '+' . h($country['phone_code']) : ''); ?>
 		</dd>
-		<dt><?php echo __('Timezone'); ?></dt>
+		<dt><?php echo __d('data', 'Timezone'); ?></dt>
 		<dd>
 			<p>
 			<?php echo $country->timezone_offset_strings? 'UTC ' . implode(', ', $country->timezone_offset_strings) : ''; ?>
@@ -49,12 +49,12 @@
 			<?php } ?>
 		</dd>
 
-		<dt><?php echo __('Special'); ?></dt>
+		<dt><?php echo __d('data', 'Special'); ?></dt>
 		<dd>
 			<?php echo h($country['special']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Address Format'); ?></dt>
+		<dt><?php echo __d('data', 'Address Format'); ?></dt>
 		<dd>
 			<?php echo nl2br(h($country['address_format'])); ?>
 			&nbsp;
@@ -66,16 +66,16 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit {0}', __('Country')), ['action' => 'edit', $country->id]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete Country'), ['action' => 'delete', $country->id], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit {0}', __d('data', 'Country')), ['action' => 'edit', $country->id]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete Country'), ['action' => 'delete', $country->id], [
 			'escapeTitle' => false,
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $country->id),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $country->id),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Countries')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Currencies/add.php
+++ b/templates/Admin/Currencies/add.php
@@ -9,7 +9,7 @@
 <div class="page form">
 <?php echo $this->Form->create($currency);?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('Currency'));?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'Currency'));?></legend>
 
 	<?php
 		echo $this->Form->control('name');
@@ -20,7 +20,7 @@
 		echo $this->Form->control('value');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/>
@@ -30,6 +30,6 @@ Das selbe gilt für den aktuellen Wechselkurs.
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Currencies')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Currencies')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/Currencies/edit.php
+++ b/templates/Admin/Currencies/edit.php
@@ -7,7 +7,7 @@
 <div class="page form">
 <?php echo $this->Form->create($currency);?>
 	<fieldset>
-		<legend><?php echo __('Edit {0}', __('Currency'));?></legend>
+		<legend><?php echo __d('data', 'Edit {0}', __d('data', 'Currency'));?></legend>
 	<?php
 		//echo $this->Form->control('id');
 		echo $this->Form->control('name');
@@ -18,19 +18,19 @@
 		echo $this->Form->control('value');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $currency->id], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $currency->id], [
 			'escapeTitle' => false,
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $currency->id),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $currency->id),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Currencies')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Currencies')), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Currencies/index.php
+++ b/templates/Admin/Currencies/index.php
@@ -9,7 +9,7 @@ use Cake\Core\Plugin;
 
 <div class="page index">
 <h2><?php
-	echo __('Currencies');?></h2>
+	echo __d('data', 'Currencies');?></h2>
 
 <table class="table">
 <tr>
@@ -19,9 +19,9 @@ use Cake\Core\Plugin;
 	<th><?php echo $this->Paginator->sort('symbol_right');?></th>
 	<th><?php echo $this->Paginator->sort('decimal_places');?></th>
 	<th><?php echo $this->Paginator->sort('value');?></th>
-	<th class="actions"><?php echo __('Status');?></th>
+	<th class="actions"><?php echo __d('data', 'Status');?></th>
 	<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 /** @var \Data\Model\Entity\Currency[] $currencies */
@@ -52,11 +52,11 @@ foreach ($currencies as $currency):
 		</td>
 		<td>
 			<span class="ajaxToggling" id="ajaxToggle-<?php echo $currency['id']?>">
-			<?php echo $this->Html->link($this->Format->yesNo($currency['active'], ['onTitle' => __('Active'), 'offTitle' => __('Inactive')]), ['action' => 'toggle', 'active', $currency['id']], ['escapeTitle' => false]); ?></span>&nbsp;&nbsp;<?php
+			<?php echo $this->Html->link($this->Format->yesNo($currency['active'], ['onTitle' => __d('data', 'Active'), 'offTitle' => __d('data', 'Inactive')]), ['action' => 'toggle', 'active', $currency['id']], ['escapeTitle' => false]); ?></span>&nbsp;&nbsp;<?php
 			if ($currency['base'] && !empty($baseCurrency)) {
-				echo $this->Format->yesNo($currency['base'], ['onTitle' => __('Base value')]);
+				echo $this->Format->yesNo($currency['base'], ['onTitle' => __d('data', 'Base value')]);
 			} else {
-				echo $this->Html->link($this->Icon->render('check-square-o', ['title' => __('Zum Basis-Wert machen')]), ['action' => 'base', $currency['id']], ['escapeTitle' => false], 'Sicher?');
+				echo $this->Html->link($this->Icon->render('check-square-o', ['title' => __d('data', 'Zum Basis-Wert machen')]), ['action' => 'base', $currency['id']], ['escapeTitle' => false], 'Sicher?');
 			} ?>
 		</td>
 		<td>
@@ -70,7 +70,7 @@ foreach ($currencies as $currency):
 				'class' => 'btn btn-link p-0 align-baseline',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $currency['id']),
+					'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $currency['id']),
 				],
 			]); ?>
 		</td>
@@ -83,8 +83,8 @@ foreach ($currencies as $currency):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add {0}', __('Currency')), ['action' => 'add']); ?></li>
-		<li><?php echo $this->Html->link(__('Update {0}', __('Currency Values')), ['action' => 'update']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add {0}', __d('data', 'Currency')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Update {0}', __d('data', 'Currency Values')), ['action' => 'update']); ?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Currencies/table.php
+++ b/templates/Admin/Currencies/table.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Full Currency Table');?></h2>
+<h2><?php echo __d('data', 'Full Currency Table');?></h2>
 
 <?php
 	echo pre($currencies);
@@ -18,6 +18,6 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add {0}', __('Currency')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add {0}', __d('data', 'Currency')), ['action' => 'add']); ?></li>
 	</ul>
 </div>

--- a/templates/Admin/Currencies/view.php
+++ b/templates/Admin/Currencies/view.php
@@ -5,39 +5,39 @@
  */
 ?>
 <div class="page view">
-<h2><?php echo __('Currency');?></h2>
+<h2><?php echo __d('data', 'Currency');?></h2>
 	<dl>
-		<dt><?php echo __('Name'); ?></dt>
+		<dt><?php echo __d('data', 'Name'); ?></dt>
 		<dd>
 			<?php echo h($currency['name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Code'); ?></dt>
+		<dt><?php echo __d('data', 'Code'); ?></dt>
 		<dd>
 			<?php echo h($currency['code']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Symbol Left'); ?></dt>
+		<dt><?php echo __d('data', 'Symbol Left'); ?></dt>
 		<dd>
 			<?php echo h($currency['symbol_left']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Symbol Right'); ?></dt>
+		<dt><?php echo __d('data', 'Symbol Right'); ?></dt>
 		<dd>
 			<?php echo h($currency['symbol_right']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Decimal Places'); ?></dt>
+		<dt><?php echo __d('data', 'Decimal Places'); ?></dt>
 		<dd>
 			<?php echo h($currency['decimal_places']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Value'); ?></dt>
+		<dt><?php echo __d('data', 'Value'); ?></dt>
 		<dd>
 			<?php echo h($currency['value']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Modified'); ?></dt>
+		<dt><?php echo __d('data', 'Modified'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($currency['modified']); ?>
 			&nbsp;
@@ -46,17 +46,17 @@
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit {0}', __('Currency')), ['action' => 'edit', $currency['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete Currency'), ['action' => 'delete', $currency['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit {0}', __d('data', 'Currency')), ['action' => 'edit', $currency['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete Currency'), ['action' => 'delete', $currency['id']], [
 			'escapeTitle' => false,
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $currency['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $currency['id']),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Currencies')), ['action' => 'index']); ?> </li>
-		<li><?php echo $this->Html->link(__('Add {0}', __('Currency')), ['action' => 'add']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Currencies')), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'Add {0}', __d('data', 'Currency')), ['action' => 'add']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Languages/add.php
+++ b/templates/Admin/Languages/add.php
@@ -4,12 +4,12 @@
  * @var \Data\Model\Entity\Language $language
  */
 ?>
-<h2><?php echo __('Add {0}', __('Language')); ?></h2>
+<h2><?php echo __d('data', 'Add {0}', __d('data', 'Language')); ?></h2>
 
 <div class="page form">
 <?php echo $this->Form->create($language);?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('Language')); ?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'Language')); ?></legend>
 	<?php
 		echo $this->Form->control('name');
 		echo $this->Form->control('ori_name');
@@ -20,13 +20,13 @@
 		//echo $this->Form->control('status');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Languages')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Languages')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/Languages/compare_iso_list_to_core.php
+++ b/templates/Admin/Languages/compare_iso_list_to_core.php
@@ -7,7 +7,7 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Languages');?></h2>
+<h2><?php echo __d('data', 'Languages');?></h2>
 ISO List contains <?php echo count($isoList['values']); ?> languages.
 <br/>
 Core contains <?php echo count($locales);?> locales (with <?php echo count($languages); ?> regional locales).
@@ -19,7 +19,7 @@ Core contains <?php echo count($locales);?> locales (with <?php echo count($lang
 	<th><?php echo $isoList['heading'][0];?></th>
 	<th><?php echo $isoList['heading'][1];?></th>
 	<th><?php echo $isoList['heading'][2];?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 $i = 0;
@@ -62,11 +62,11 @@ foreach ($isoList['values'] as $language):
 <h3>Only in core or faulty</h3>
 <table class="table"><tr>
 	<th>&nbsp;</th>
-	<th><?php echo __('Language');?></th>
-	<th><?php echo __('Code');?></th>
-	<th><?php echo __('Locale');?></th>
-	<th><?php echo __('Status');?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th><?php echo __d('data', 'Language');?></th>
+	<th><?php echo __d('data', 'Code');?></th>
+	<th><?php echo __d('data', 'Locale');?></th>
+	<th><?php echo __d('data', 'Status');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 $isoLocales = [];
@@ -136,6 +136,6 @@ foreach ($locales as $key => $locale):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Languages')), ['action' => 'index']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Languages')), ['action' => 'index']); ?></li>
 	</ul>
 </div>

--- a/templates/Admin/Languages/compare_to_iso_list.php
+++ b/templates/Admin/Languages/compare_to_iso_list.php
@@ -10,7 +10,7 @@ use Shim\Filesystem\Folder;
 ?>
 
 <div class="page index">
-<h2><?php echo __('Languages');?></h2>
+<h2><?php echo __d('data', 'Languages');?></h2>
 ISO List contains <?php echo count($isoList['values']); ?> languages.
 <br/>
 Local DB contains <?php echo count($languages); ?> locales.
@@ -21,8 +21,8 @@ Local DB contains <?php echo count($languages); ?> locales.
 	<th><?php echo $isoList['heading'][0];?></th>
 	<th><?php echo $isoList['heading'][1];?></th>
 	<th><?php echo $isoList['heading'][2];?></th>
-	<th><?php echo __('Locales'); ?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th><?php echo __d('data', 'Locales'); ?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 $i = 0;
@@ -86,6 +86,6 @@ foreach ($isoList['values'] as $language):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Languages')), ['action' => 'index']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Languages')), ['action' => 'index']); ?></li>
 	</ul>
 </div>

--- a/templates/Admin/Languages/edit.php
+++ b/templates/Admin/Languages/edit.php
@@ -4,12 +4,12 @@
  * @var \Data\Model\Entity\Language $language
  */
 ?>
-<h2><?php echo __('Edit {0}', __('Language')); ?></h2>
+<h2><?php echo __d('data', 'Edit {0}', __d('data', 'Language')); ?></h2>
 
 <div class="page form">
 <?php echo $this->Form->create($language);?>
 	<fieldset>
-		<legend><?php echo __('Edit {0}', __('Language')); ?></legend>
+		<legend><?php echo __d('data', 'Edit {0}', __d('data', 'Language')); ?></legend>
 	<?php
 		//echo $this->Form->control('id');
 		echo $this->Form->control('name');
@@ -21,21 +21,21 @@
 		echo $this->Form->control('status');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $language->id], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $language->id], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $language->id),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $language->id),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Languages')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Languages')), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Languages/import_from_core.php
+++ b/templates/Admin/Languages/import_from_core.php
@@ -4,12 +4,12 @@
  * @var \Data\Model\Entity\Language $language
  */
 ?>
-<h2><?php echo __('Import {0}', __('Languages')); ?></h2>
+<h2><?php echo __d('data', 'Import {0}', __d('data', 'Languages')); ?></h2>
 
 <div class="page form">
 <?php echo $this->Form->create($language);?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('Language')); ?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'Language')); ?></legend>
 	<?php
 		//echo $this->Form->control('name');
 		//echo $this->Form->control('ori_name');
@@ -18,13 +18,13 @@
 		//echo $this->Form->control('status');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <br/><br/>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Languages')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Languages')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/Languages/index.php
+++ b/templates/Admin/Languages/index.php
@@ -11,15 +11,15 @@ use Cake\Core\Plugin;
 ?>
 
 <div class="page index">
-<h2><?php echo __('Languages');?></h2>
+<h2><?php echo __d('data', 'Languages');?></h2>
 
 <?php if (Plugin::isLoaded('Search')) { ?>
 <div class="search-box">
 <?php
 echo $this->Form->create(null, ['valueSources' => 'query']);
-echo $this->Form->control('search', ['placeholder' => __('wildcardSearch {0} and {1}', '*', '?')]);
-echo $this->Form->control('dir', ['label' => __('Direction'), 'options' => $language::directions(), 'empty' => Configure::read('Select.defaultBefore') . __('noSelection') . Configure::read('Select.defaultAfter')]);
-echo $this->Form->button(__('Search'), []);
+echo $this->Form->control('search', ['placeholder' => __d('data', 'wildcardSearch {0} and {1}', '*', '?')]);
+echo $this->Form->control('dir', ['label' => __d('data', 'Direction'), 'options' => $language::directions(), 'empty' => Configure::read('Select.defaultBefore') . __d('data', 'noSelection') . Configure::read('Select.defaultAfter')]);
+echo $this->Form->button(__d('data', 'Search'), []);
 echo $this->Form->end();
 ?>
 <?php if ($this->Search->isSearch()) {
@@ -38,7 +38,7 @@ echo $this->Form->end();
 	<th><?php echo $this->Paginator->sort('direction');?></th>
 	<th><?php echo $this->Paginator->sort('status');?></th>
 	<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 foreach ($languages as $language):
@@ -68,7 +68,7 @@ foreach ($languages as $language):
 			<?php echo $language::directions($language->direction); ?>
 		</td>
 		<td>
-			<?php echo $this->Format->yesNo($language['status'], ['onTitle' => __('Active'), 'offTitle' => __('Inactive')]); ?>
+			<?php echo $this->Format->yesNo($language['status'], ['onTitle' => __d('data', 'Active'), 'offTitle' => __d('data', 'Inactive')]); ?>
 		</td>
 		<td>
 			<?php echo $this->Time->niceDate($language['modified']); ?>
@@ -81,7 +81,7 @@ foreach ($languages as $language):
 				'class' => 'btn btn-link p-0 align-baseline',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $language['id']),
+					'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $language['id']),
 				],
 			]); ?>
 		</td>
@@ -101,11 +101,11 @@ The language flags are actually country flags. Due to incompatabities between co
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add {0}', __('Language')), ['action' => 'add']); ?></li>
-		<li><?php echo $this->Html->link(__('Compare {0}', __('Languages')), ['action' => 'compare_to_iso_list']); ?></li>
-		<li><?php echo $this->Html->link(__('Compare {0} to core', __('Languages')), ['action' => 'compare_iso_list_to_core']); ?></li>
-		<li><?php echo $this->Html->link(__('Import {0} from Core', __('Language')), ['action' => 'import_from_core'], [], __('Sure?')); ?></li>
-		<li><?php echo $this->Html->link(__('Set primary languages active'), ['action' => 'set_primary_languages_active'], [], __('Sure?')); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add {0}', __d('data', 'Language')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Compare {0}', __d('data', 'Languages')), ['action' => 'compare_to_iso_list']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Compare {0} to core', __d('data', 'Languages')), ['action' => 'compare_iso_list_to_core']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Import {0} from Core', __d('data', 'Language')), ['action' => 'import_from_core'], [], __d('data', 'Sure?')); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Set primary languages active'), ['action' => 'set_primary_languages_active'], [], __d('data', 'Sure?')); ?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/Languages/view.php
+++ b/templates/Admin/Languages/view.php
@@ -5,39 +5,39 @@
  */
 ?>
 <div class="page view">
-<h2><?php echo __('Language');?></h2>
+<h2><?php echo __d('data', 'Language');?></h2>
 	<dl>
-		<dt><?php echo __('Name'); ?></dt>
+		<dt><?php echo __d('data', 'Name'); ?></dt>
 		<dd>
 			<?php echo h($language['name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Ori Name'); ?></dt>
+		<dt><?php echo __d('data', 'Ori Name'); ?></dt>
 		<dd>
 			<?php echo h($language['ori_name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Code'); ?></dt>
+		<dt><?php echo __d('data', 'Code'); ?></dt>
 		<dd>
 			<?php echo h($language['code']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Locale'); ?></dt>
+		<dt><?php echo __d('data', 'Locale'); ?></dt>
 		<dd>
 			<?php echo h($language['locale']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Locale Fallback'); ?></dt>
+		<dt><?php echo __d('data', 'Locale Fallback'); ?></dt>
 		<dd>
 			<?php echo h($language['locale_fallback']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Status'); ?></dt>
+		<dt><?php echo __d('data', 'Status'); ?></dt>
 		<dd>
 			<?php echo h($language['status']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Modified'); ?></dt>
+		<dt><?php echo __d('data', 'Modified'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($language['modified']); ?>
 			&nbsp;
@@ -49,15 +49,15 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit {0}', __('Language')), ['action' => 'edit', $language['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Language')), ['action' => 'delete', $language['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit {0}', __d('data', 'Language')), ['action' => 'edit', $language['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete {0}', __d('data', 'Language')), ['action' => 'delete', $language['id']], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $language['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $language['id']),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Languages')), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Languages')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypeImages/add.php
+++ b/templates/Admin/MimeTypeImages/add.php
@@ -8,7 +8,7 @@
 <div class="page form">
 <?php echo $this->Form->create($mimeTypeImage, ['type' => 'file']);?>
 	<fieldset>
-		<legend><?php echo __('Add Mime Type Image');?></legend>
+		<legend><?php echo __d('data', 'Add Mime Type Image');?></legend>
 	<?php
 		echo $this->Form->control('name');
 		echo '<br/>';
@@ -22,10 +22,10 @@
 		echo $this->Form->control('details', ['type' => 'textarea']);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List Mime Type Images'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Type Images'), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/MimeTypeImages/allocate.php
+++ b/templates/Admin/MimeTypeImages/allocate.php
@@ -8,7 +8,7 @@
 <div class="page form">
 <?php echo $this->Form->create($mimeTypeImage);?>
 	<fieldset>
-		<legend><?php echo __('Add Mime Type Image');?></legend>
+		<legend><?php echo __d('data', 'Add Mime Type Image');?></legend>
 	<?php
 		if (!empty($images)) {
 			//echo $this->Form->control('images', array('type'=>'select','multiple'=>'checkbox','options'=>$images,'label'=>false));
@@ -36,11 +36,11 @@
 	?>
 
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); ?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); ?>
 <?php echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List Mime Type Images'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Type Images'), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/MimeTypeImages/edit.php
+++ b/templates/Admin/MimeTypeImages/edit.php
@@ -8,7 +8,7 @@
 <div class="page form">
 <?php echo $this->Form->create($mimeTypeImage, ['type' => 'file']);?>
 	<fieldset>
-		<legend><?php echo __('Edit Mime Type Image');?></legend>
+		<legend><?php echo __d('data', 'Edit Mime Type Image');?></legend>
 	<?php
 		//echo $this->Form->control('id');
 		echo $this->Form->control('name');
@@ -23,18 +23,18 @@
 		echo $this->Form->control('details', ['type' => 'textarea']);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('MimeTypeImages.id')], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $this->Form->getSourceValue('MimeTypeImages.id')], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('MimeTypeImage.id')),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $this->Form->getSourceValue('MimeTypeImage.id')),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List Mime Type Images'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Type Images'), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypeImages/import.php
+++ b/templates/Admin/MimeTypeImages/import.php
@@ -11,7 +11,7 @@
 
 <?php if (!empty($alreadyIn) || !empty($fileExtensions)) { ?>
 	<fieldset>
-		<legend><?php echo __('Confirm and Save');?></legend>
+		<legend><?php echo __d('data', 'Confirm and Save');?></legend>
 	<?php echo count($alreadyIn)?> bereits vorhanden: <ul style="margin-left:160px"><?php echo implode(',', $alreadyIn)?>
 	<?php if (empty($alreadyIn)) { ?>
 		- - -
@@ -34,16 +34,16 @@
 <?php } ?>
 
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('Extensions'));?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'Extensions'));?></legend>
 	<?php
 		echo $this->Form->control('import', ['type' => 'textarea']);
 	?>
 	Eine mit Komma, Leerzeichen, NewLine, etc. separierte Liste, die nur Endungen (exe, jpg, ...) oder Dateien (1.jpg, 2.gif) enthält, deren Endungen dann importiert werden.
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List Mime Type Images'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Type Images'), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/MimeTypeImages/index.php
+++ b/templates/Admin/MimeTypeImages/index.php
@@ -5,19 +5,19 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Mime Type Images');?></h2>
+<h2><?php echo __d('data', 'Mime Type Images');?></h2>
 
 <table class="table">
 <tr>
-	<th><?php echo __('Icon');?></th>
+	<th><?php echo __d('data', 'Icon');?></th>
 	<th><?php echo $this->Paginator->sort('name');?></th>
 	<th><?php echo $this->Paginator->sort('ext');?></th>
 	<th><?php echo $this->Paginator->sort('active');?></th>
-	<th><?php echo __('Usage');?></th>
+	<th><?php echo __d('data', 'Usage');?></th>
 	<th><?php echo $this->Paginator->sort('details');?></th>
 	<th><?php echo $this->Paginator->sort('created', null, ['direction' => 'desc']);?></th>
 	<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 $i = 0;
@@ -89,14 +89,14 @@ foreach ($mimeTypeImages as $mimeTypeImage):
 				'class' => 'btn btn-link p-0 align-baseline',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $mimeTypeImage['id']),
+					'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $mimeTypeImage['id']),
 				],
 			]); ?>
 			<?php
 				if (isset($imageWidth) && isset($imageHeight) && $imageWidth != 16 && $imageHeight != 16) {
-					echo $this->Icon->render('expand', ['title' => __('Größe ist nicht 16x16, sondern ' . $imageWidth . 'x' . $imageHeight . '! Anpassen...')]);
+					echo $this->Icon->render('expand', ['title' => __d('data', 'Größe ist nicht 16x16, sondern ' . $imageWidth . 'x' . $imageHeight . '! Anpassen...')]);
 				} elseif (empty($mimeTypeImage['ext']) || !empty($mimeTypeImage['warning'])) {
-					echo $this->Html->link($this->Icon->render('google', ['title' => __('Search with Google')]), 'http://images.google.de/images?q=' . $mimeTypeImage['name'] . '+imagesize%3A16x16&btnG=Bilder-Suche', ['escapeTitle' => false]);
+					echo $this->Html->link($this->Icon->render('google', ['title' => __d('data', 'Search with Google')]), 'http://images.google.de/images?q=' . $mimeTypeImage['name'] . '+imagesize%3A16x16&btnG=Bilder-Suche', ['escapeTitle' => false]);
 				}
 			?>
 		</td>
@@ -107,10 +107,10 @@ foreach ($mimeTypeImages as $mimeTypeImage):
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add Mime Type Image'), ['action' => 'add']); ?></li>
-		<li><?php echo $this->Html->link(__('(Auto-) Allocate Icons Files'), ['action' => 'allocate']); ?></li>
-		<li><?php echo $this->Html->link(__('Import Extensions'), ['action' => 'import']); ?></li>
-		<li><?php echo $this->Html->link(__('Search Icon on google.de'), 'http://images.google.de/images?q=icon+imagesize%3A16x16&btnG=Bilder-Suche'); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add Mime Type Image'), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', '(Auto-) Allocate Icons Files'), ['action' => 'allocate']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Import Extensions'), ['action' => 'import']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Search Icon on google.de'), 'http://images.google.de/images?q=icon+imagesize%3A16x16&btnG=Bilder-Suche'); ?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypeImages/view.php
+++ b/templates/Admin/MimeTypeImages/view.php
@@ -5,29 +5,29 @@
  */
 ?>
 <div class="page view">
-<h2><?php echo __('Mime Type Image');?></h2>
+<h2><?php echo __d('data', 'Mime Type Image');?></h2>
 	<dl>
-		<dt><?php echo __('Name'); ?></dt>
+		<dt><?php echo __d('data', 'Name'); ?></dt>
 		<dd>
 			<?php echo h($mimeTypeImage['name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Ext'); ?></dt>
+		<dt><?php echo __d('data', 'Ext'); ?></dt>
 		<dd>
 			<?php echo h($mimeTypeImage['ext']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Active'); ?></dt>
+		<dt><?php echo __d('data', 'Active'); ?></dt>
 		<dd>
 			<?php echo h($mimeTypeImage['active']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Created'); ?></dt>
+		<dt><?php echo __d('data', 'Created'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($mimeTypeImage['created']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Modified'); ?></dt>
+		<dt><?php echo __d('data', 'Modified'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($mimeTypeImage['modified']); ?>
 			&nbsp;
@@ -36,17 +36,17 @@
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit Mime Type Image'), ['action' => 'edit', $mimeTypeImage['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete Mime Type Image'), ['action' => 'delete', $mimeTypeImage['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit Mime Type Image'), ['action' => 'edit', $mimeTypeImage['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete Mime Type Image'), ['action' => 'delete', $mimeTypeImage['id']], [
 			'escapeTitle' => false,
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $mimeTypeImage['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $mimeTypeImage['id']),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List Mime Type Images'), ['action' => 'index']); ?> </li>
-		<li><?php echo $this->Html->link(__('Add Mime Type Image'), ['action' => 'add']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Type Images'), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'Add Mime Type Image'), ['action' => 'add']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypes/add.php
+++ b/templates/Admin/MimeTypes/add.php
@@ -18,7 +18,7 @@ $this->Html->script('jquery/plugins/jquery.dd.js');?>
 <div class="page form">
 <?php echo $this->Form->create($mimeType);?>
 	<fieldset>
-		<legend><?php echo __('Add Mime Type');?></legend>
+		<legend><?php echo __d('data', 'Add Mime Type');?></legend>
 	<?php
 		foreach ($mimeTypeImages as $key => $image) {
 			//$mimeTypeImages[$key] = 's'.$this->Html->image(IMG_MIMETYPES.$image).' '.$image;
@@ -35,10 +35,10 @@ $this->Html->script('jquery/plugins/jquery.dd.js');?>
 		echo $this->Form->control('active');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Types'), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/MimeTypes/allocate.php
+++ b/templates/Admin/MimeTypes/allocate.php
@@ -11,6 +11,6 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Types'), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/MimeTypes/allocate_by_type.php
+++ b/templates/Admin/MimeTypes/allocate_by_type.php
@@ -25,6 +25,6 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Types'), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/MimeTypes/detect_by_extension.php
+++ b/templates/Admin/MimeTypes/detect_by_extension.php
@@ -6,7 +6,7 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Mime Type Detection');?></h2>
+<h2><?php echo __d('data', 'Mime Type Detection');?></h2>
 <?php
 foreach ($extensions as $extension) {
 	echo 'test.' . $extension . ', ';
@@ -19,7 +19,7 @@ foreach ($extensions as $extension) {
 <?php echo $this->Form->create($mimeType, ['type' => 'file']);?>
 
 	<fieldset>
-		<legend><?php echo __('Test');?></legend>
+		<legend><?php echo __d('data', 'Test');?></legend>
 	<?php
 		echo $this->Form->control('file', ['type' => 'file']);
 	?>

--- a/templates/Admin/MimeTypes/edit.php
+++ b/templates/Admin/MimeTypes/edit.php
@@ -18,7 +18,7 @@ $this->Html->script('jquery/plugins/jquery.dd.js');?>
 <div class="page form">
 <?php echo $this->Form->create($mimeType);?>
 	<fieldset>
-		<legend><?php echo __('Edit Mime Type');?></legend>
+		<legend><?php echo __d('data', 'Edit Mime Type');?></legend>
 	<?php
 		//echo $this->Form->control('id');
 
@@ -33,18 +33,18 @@ $this->Html->script('jquery/plugins/jquery.dd.js');?>
 		echo $this->Form->control('active');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('MimeType.id')], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $this->Form->getSourceValue('MimeType.id')], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('MimeType.id')),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $this->Form->getSourceValue('MimeType.id')),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Types'), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/MimeTypes/from_core.php
+++ b/templates/Admin/MimeTypes/from_core.php
@@ -22,7 +22,7 @@ Currently Media View has <b><?php echo count($mimeTypes)?> MimeTypes</b> listed<
 <div class="page form">
 <?php echo $this->Form->create($mimeType);?>
 	<fieldset>
-		<legend><?php echo __('Add Mime Type');?></legend>
+		<legend><?php echo __d('data', 'Add Mime Type');?></legend>
 	Zur manuellen Klärung:
 	<?php
 		pr($manualRes);
@@ -33,10 +33,10 @@ Currently Media View has <b><?php echo count($mimeTypes)?> MimeTypes</b> listed<
 		pr($report['error']);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Types'), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/MimeTypes/from_file.php
+++ b/templates/Admin/MimeTypes/from_file.php
@@ -18,12 +18,12 @@ The imported data has <b><?php echo count($mimeTypes)?> MimeTypes</b> listed<br/
 <div class="page form">
 <?php echo $this->Form->create($mimeType);?>
 	<fieldset>
-		<legend><?php echo __('Add Mime Type');?></legend>
+		<legend><?php echo __d('data', 'Add Mime Type');?></legend>
 	<?php
 		pr($report);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <?php } ?>
@@ -33,6 +33,6 @@ The imported data has <b><?php echo count($mimeTypes)?> MimeTypes</b> listed<br/
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Types'), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/MimeTypes/index.php
+++ b/templates/Admin/MimeTypes/index.php
@@ -7,12 +7,12 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Mime Types');?></h2>
+<h2><?php echo __d('data', 'Mime Types');?></h2>
 
 <div class="searchWrapper">
 <?php echo $this->Form->create();?>
 <div class="floatLeft"><?php echo $this->Form->control('Form.search', ['label' => '(Teil)Suche:', 'value' => $searchStr]);?></div>
-<div class="floatLeft"><?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?></div>
+<div class="floatLeft"><?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?></div>
 <?php
 if (!empty($searchStr)) {
 	echo '<div class="floatRight">' . $this->Html->link('Wieder alle anzeigen', ['action' => 'index', 'clear' => 'search']) . '</div>';
@@ -26,7 +26,7 @@ if (!empty($searchStr) && !empty($allCount)) {
 	} else {
 		$perCent = ceil(($currentCount / $allCount) * 100);
 	}
-	echo '<br class="clear"/><div>' . $this->Html->image('icons/results.gif') . ' Treffer: <b>' . $perCent . '%</b> (' . $currentCount . __(' out of ') . $allCount . ')</div>';
+	echo '<br class="clear"/><div>' . $this->Html->image('icons/results.gif') . ' Treffer: <b>' . $perCent . '%</b> (' . $currentCount . __d('data', ' out of ') . $allCount . ')</div>';
 }
 ?>
 </div>
@@ -34,7 +34,7 @@ if (!empty($searchStr) && !empty($allCount)) {
 
 <table class="table">
 <tr>
-	<th><?php echo __('Icon');?></th>
+	<th><?php echo __d('data', 'Icon');?></th>
 	<th><?php echo $this->Paginator->sort('ext');?></th>
 	<th><?php echo $this->Paginator->sort('name');?></th>
 	<th><?php echo $this->Paginator->sort('type');?></th>
@@ -42,7 +42,7 @@ if (!empty($searchStr) && !empty($allCount)) {
 	<th><?php echo $this->Paginator->sort('core');?></th>
 	<th><?php echo $this->Paginator->sort('created', null, ['direction' => 'desc']);?></th>
 	<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 $i = 0;
@@ -101,7 +101,7 @@ foreach ($mimeTypes as $mimeType):
 				'class' => 'btn btn-link p-0 align-baseline',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $mimeType['id']),
+					'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $mimeType['id']),
 				],
 			]); ?>
 		</td>
@@ -114,12 +114,12 @@ foreach ($mimeTypes as $mimeType):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Add Mime Type'), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Add Mime Type'), ['action' => 'add']); ?></li>
 
-		<li><?php echo $this->Html->link(__('(Auto-) Allocate Icons by Extension'), ['action' => 'allocate']); ?></li>
-		<li><?php echo $this->Html->link(__('Allocate Icons by Type (Groups)'), ['action' => 'allocateByType']); ?></li>
-		<li><?php echo $this->Html->link(__('Import from Core Media View'), ['action' => 'fromCore']); ?></li>
-		<li><?php echo $this->Html->link(__('Import from File'), ['action' => 'fromFile']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', '(Auto-) Allocate Icons by Extension'), ['action' => 'allocate']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Allocate Icons by Type (Groups)'), ['action' => 'allocateByType']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Import from Core Media View'), ['action' => 'fromCore']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Import from File'), ['action' => 'fromFile']); ?></li>
 	</ul>
 </div>
 <br/>

--- a/templates/Admin/MimeTypes/manual_input.php
+++ b/templates/Admin/MimeTypes/manual_input.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Manual Input');?></h2>
+<h2><?php echo __d('data', 'Manual Input');?></h2>
 
 
 

--- a/templates/Admin/MimeTypes/view.php
+++ b/templates/Admin/MimeTypes/view.php
@@ -5,29 +5,29 @@
  */
 ?>
 <div class="page view">
-<h2><?php echo __('Mime Type');?></h2>
+<h2><?php echo __d('data', 'Mime Type');?></h2>
 	<dl>
-		<dt><?php echo __('Name'); ?></dt>
+		<dt><?php echo __d('data', 'Name'); ?></dt>
 		<dd>
 			<?php echo h($mimeType['name']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Type'); ?></dt>
+		<dt><?php echo __d('data', 'Type'); ?></dt>
 		<dd>
 			<?php echo h($mimeType['type']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Active'); ?></dt>
+		<dt><?php echo __d('data', 'Active'); ?></dt>
 		<dd>
 			<?php echo h($mimeType['active']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Created'); ?></dt>
+		<dt><?php echo __d('data', 'Created'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($mimeType['created']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Modified'); ?></dt>
+		<dt><?php echo __d('data', 'Modified'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($mimeType['modified']); ?>
 			&nbsp;
@@ -36,17 +36,17 @@
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit Mime Type'), ['action' => 'edit', $mimeType['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete Mime Type'), ['action' => 'delete', $mimeType['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit Mime Type'), ['action' => 'edit', $mimeType['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete Mime Type'), ['action' => 'delete', $mimeType['id']], [
 			'escapeTitle' => false,
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $mimeType['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $mimeType['id']),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List Mime Types'), ['action' => 'index']); ?> </li>
-		<li><?php echo $this->Html->link(__('Add Mime Type'), ['action' => 'add']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List Mime Types'), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'Add Mime Type'), ['action' => 'add']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/PostalCodes/add.php
+++ b/templates/Admin/PostalCodes/add.php
@@ -5,11 +5,11 @@
  */
 ?>
 <div class="page form">
-<h2><?php echo __('Add {0}', __('Postal Code')); ?></h2>
+<h2><?php echo __d('data', 'Add {0}', __d('data', 'Postal Code')); ?></h2>
 
 <?php echo $this->Form->create($postalCode);?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('Postal Code')); ?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'Postal Code')); ?></legend>
 	<?php
 		echo $this->Form->control('code');
 		echo $this->Form->control('country_id');
@@ -18,12 +18,12 @@
 		echo $this->Form->control('official_address');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <div class="actions">
 	<ul>
 
-		<li><?php echo $this->Html->link(__('List {0}', __('Postal Codes')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Postal Codes')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/PostalCodes/edit.php
+++ b/templates/Admin/PostalCodes/edit.php
@@ -5,11 +5,11 @@
  */
 ?>
 <div class="page form">
-<h2><?php echo __('Edit {0}', __('Postal Code')); ?></h2>
+<h2><?php echo __d('data', 'Edit {0}', __d('data', 'Postal Code')); ?></h2>
 
 <?php echo $this->Form->create($postalCode);?>
 	<fieldset>
-		<legend><?php echo __('Edit {0}', __('Postal Code')); ?></legend>
+		<legend><?php echo __d('data', 'Edit {0}', __d('data', 'Postal Code')); ?></legend>
 	<?php
 		//echo $this->Form->control('id');
 		echo $this->Form->control('code');
@@ -19,20 +19,20 @@
 		echo $this->Form->control('official_address');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <div class="actions">
 	<ul>
 
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $this->Form->getSourceValue('PostalCode.id')], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $this->Form->getSourceValue('PostalCode.id')], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $this->Form->getSourceValue('PostalCode.id')),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $this->Form->getSourceValue('PostalCode.id')),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Postal Codes')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Postal Codes')), ['action' => 'index']);?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/PostalCodes/index.php
+++ b/templates/Admin/PostalCodes/index.php
@@ -9,14 +9,14 @@
 <div class="searchBox" style="float: right;">
 <?php
 	echo $this->Form->create(null, ['valueSources' => 'query']);
-	echo $this->Form->control('code', ['placeholder' => __('Placeholder') . ': * und ?']);
+	echo $this->Form->control('code', ['placeholder' => __d('data', 'Placeholder') . ': * und ?']);
 	echo $this->Form->control('country_id', ['empty' => ' - egal - ']);
-	echo $this->Form->button(__('Search'));
+	echo $this->Form->button(__d('data', 'Search'));
 	echo $this->Form->end();
 ?>
 </div>
 
-	<h2><?php echo __('Postal Codes');?></h2>
+	<h2><?php echo __d('data', 'Postal Codes');?></h2>
 
 	<table class="table">
 		<tr>
@@ -27,7 +27,7 @@
 		<th><?php echo $this->Paginator->sort('official_address');?></th>
 		<th><?php echo $this->Paginator->sort('created', null, ['direction' => 'desc']);?></th>
 		<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-		<th class="actions"><?php echo __('Actions');?></th>
+		<th class="actions"><?php echo __d('data', 'Actions');?></th>
 	</tr>
 <?php
 $i = 0;
@@ -62,7 +62,7 @@ foreach ($postalCodes as $postalCode): ?>
 				'class' => 'btn btn-link p-0 align-baseline',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $postalCode['id']),
+					'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $postalCode['id']),
 				],
 			]); ?>
 		</td>
@@ -78,9 +78,9 @@ foreach ($postalCodes as $postalCode): ?>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('New {0}', __('Postal Code')), ['action' => 'add']); ?></li>
-		<li><?php echo $this->Html->link(__('Query'), ['action' => 'query']); ?></li>
-		<li><?php echo $this->Html->link(__('Geolocate'), ['action' => 'geolocate']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'New {0}', __d('data', 'Postal Code')), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Query'), ['action' => 'query']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Geolocate'), ['action' => 'geolocate']); ?></li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/PostalCodes/query.php
+++ b/templates/Admin/PostalCodes/query.php
@@ -6,18 +6,18 @@
  */
 ?>
 <div class="page form">
-<h2><?php echo __('Query {0}', __('Geo Data')); ?></h2>
+<h2><?php echo __d('data', 'Query {0}', __d('data', 'Geo Data')); ?></h2>
 
 <?php echo $this->Form->create($postalCode);?>
 	<fieldset>
-		<legend><?php echo __('Enter Postal Code, City, Address or other Geo Data'); ?></legend>
+		<legend><?php echo __d('data', 'Enter Postal Code, City, Address or other Geo Data'); ?></legend>
 	<?php
 		echo $this->Form->control('address');
 		echo $this->Form->control('allow_inconclusive', ['type' => 'checkbox']);
 		echo $this->Form->control('min_accuracy', []);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <div>
@@ -32,6 +32,6 @@
 <div class="actions">
 	<ul>
 
-		<li><?php echo $this->Html->link(__('List {0}', __('Postal Codes')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Postal Codes')), ['action' => 'index']);?></li>
 	</ul>
 </div>

--- a/templates/Admin/PostalCodes/view.php
+++ b/templates/Admin/PostalCodes/view.php
@@ -5,46 +5,46 @@
  */
 ?>
 <div class="page view">
-<h2><?php echo __('Postal Code');?></h2>
+<h2><?php echo __d('data', 'Postal Code');?></h2>
 	<dl>
-		<dt><?php echo __('Code'); ?></dt>
+		<dt><?php echo __d('data', 'Code'); ?></dt>
 		<dd>
 			<?php echo h($postalCode['code']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Country Id'); ?></dt>
+		<dt><?php echo __d('data', 'Country Id'); ?></dt>
 		<dd>
 			<?php echo h($postalCode->country->name); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Lat'); ?></dt>
+		<dt><?php echo __d('data', 'Lat'); ?></dt>
 		<dd>
 			<?php echo $this->Number->format($postalCode['lat']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Lng'); ?></dt>
+		<dt><?php echo __d('data', 'Lng'); ?></dt>
 		<dd>
 			<?php echo $this->Number->format($postalCode['lng']); ?>
 			&nbsp;
 		</dd>
 <?php if ((int)$postalCode['lat'] || (int)$postalCode['lng']) { ?>
-		<dt><?php echo __('Map'); ?></dt>
+		<dt><?php echo __d('data', 'Map'); ?></dt>
 		<dd>
 			<?php echo $this->GoogleMap->staticMap(['size' => '640x600', 'zoom' => 12, 'markers' => $this->GoogleMap->staticMarkers([['lat' => $postalCode['lat'], 'lng' => $postalCode['lng']]])]); ?>
 		</dd>
 <?php } ?>
-		<dt><?php echo __('Official Address'); ?></dt>
+		<dt><?php echo __d('data', 'Official Address'); ?></dt>
 		<dd>
 			<?php echo h($postalCode['official_address']); ?>
 			&nbsp;
 		</dd>
-		<dt><?php echo __('Created'); ?></dt>
+		<dt><?php echo __d('data', 'Created'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($postalCode['created']); ?>
 			&nbsp;
 		</dd>
 <?php if ($postalCode['created'] != $postalCode['modified']) { ?>
-		<dt><?php echo __('Modified'); ?></dt>
+		<dt><?php echo __d('data', 'Modified'); ?></dt>
 		<dd>
 			<?php echo $this->Time->niceDate($postalCode['modified']); ?>
 			&nbsp;
@@ -55,15 +55,15 @@
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('Edit {0}', __('Postal Code')), ['action' => 'edit', $postalCode['id']]); ?> </li>
-		<li><?php echo $this->Form->postButton(__('Delete {0}', __('Postal Code')), ['action' => 'delete', $postalCode['id']], [
+		<li><?php echo $this->Html->link(__d('data', 'Edit {0}', __d('data', 'Postal Code')), ['action' => 'edit', $postalCode['id']]); ?> </li>
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete {0}', __d('data', 'Postal Code')), ['action' => 'delete', $postalCode['id']], [
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $postalCode['id']),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $postalCode['id']),
 			],
 		]); ?> </li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Postal Codes')), ['action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Postal Codes')), ['action' => 'index']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/States/add.php
+++ b/templates/Admin/States/add.php
@@ -6,19 +6,19 @@
 <div class="page form">
 <?php echo $this->Form->create();?>
 	<fieldset>
-		<legend><?php echo __('Add {0}', __('State'));?></legend>
+		<legend><?php echo __d('data', 'Add {0}', __d('data', 'State'));?></legend>
 	<?php
-		echo $this->Form->control('country_id', ['empty' => ' - [ ' . __('pleaseSelect') . ' ] - ', 'required' => 1]);
+		echo $this->Form->control('country_id', ['empty' => ' - [ ' . __d('data', 'pleaseSelect') . ' ] - ', 'required' => 1]);
 		echo $this->Form->control('name', ['required' => 1]);
 		echo $this->Form->control('ori_name');
 		echo $this->Form->control('code');
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 </div>
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('States')), ['action' => 'index']);?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['controller' => 'Countries', 'action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'States')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Countries')), ['controller' => 'Countries', 'action' => 'index']); ?> </li>
 	</ul>
 </div>

--- a/templates/Admin/States/edit.php
+++ b/templates/Admin/States/edit.php
@@ -7,32 +7,32 @@
 <div class="page form">
 <?php echo $this->Form->create($state);?>
 	<fieldset>
-		<legend><?php echo __('Edit {0}', __('State'));?></legend>
+		<legend><?php echo __d('data', 'Edit {0}', __d('data', 'State'));?></legend>
 	<?php
 		//echo $this->Form->control('id');
-		echo $this->Form->control('country_id', ['empty' => ' - [ ' . __('pleaseSelect') . ' ]- ', 'required' => 1]);
+		echo $this->Form->control('country_id', ['empty' => ' - [ ' . __d('data', 'pleaseSelect') . ' ]- ', 'required' => 1]);
 		echo $this->Form->control('name', ['required' => 1]);
 		echo $this->Form->control('ori_name');
 		echo $this->Form->control('code');
 
 	?>
 	</fieldset>
-	<?php echo $this->Form->submit(__('Submit')); ?>
+	<?php echo $this->Form->submit(__d('data', 'Submit')); ?>
 <?php echo $this->Form->end();?>
 </div>
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Form->postButton(__('Delete'), ['action' => 'delete', $state->id], [
+		<li><?php echo $this->Form->postButton(__d('data', 'Delete'), ['action' => 'delete', $state->id], [
 			'escapeTitle' => false,
 			'class' => 'btn btn-link p-0 align-baseline',
 			'form' => [
 				'class' => 'd-inline',
-				'data-confirm-message' => __('Are you sure you want to delete # {0}?', $state->id),
+				'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $state->id),
 			],
 		]); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('States')), ['action' => 'index']);?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['controller' => 'countries', 'action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'States')), ['action' => 'index']);?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Countries')), ['controller' => 'countries', 'action' => 'index']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/States/index.php
+++ b/templates/Admin/States/index.php
@@ -23,7 +23,7 @@ use Cake\Core\Plugin;
 </div>
 <?php } ?>
 
-<h2><?php echo __('States');?></h2>
+<h2><?php echo __d('data', 'States');?></h2>
 
 <table class="table">
 <tr>
@@ -31,9 +31,9 @@ use Cake\Core\Plugin;
 	<th><?php echo $this->Paginator->sort('name');?></th>
 	<th><?php echo $this->Paginator->sort('ori_name');?></th>
 	<th><?php echo $this->Paginator->sort('code');?></th>
-	<th><?php echo __('Coordinates');?></th>
+	<th><?php echo __d('data', 'Coordinates');?></th>
 	<th><?php echo $this->Paginator->sort('modified', null, ['direction' => 'desc']);?></th>
-	<th class="actions"><?php echo __('Actions');?></th>
+	<th class="actions"><?php echo __d('data', 'Actions');?></th>
 </tr>
 <?php
 foreach ($states as $state):
@@ -67,12 +67,12 @@ foreach ($states as $state):
 
 				if (Configure::read('GoogleMap.key')) {
 					$mapMarkers = $this->GoogleMap->staticMarkers($markers);
-					echo ' ' . $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->staticMapUrl(['center' => $state->lat . ',' . $state->lng, 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 5]), ['id' => 'googleMap', 'class' => 'internal zoom-image highslideImage', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
+					echo ' ' . $this->Html->link($this->Icon->render('view', [], ['title' => __d('data', 'Show')]), $this->GoogleMap->staticMapUrl(['center' => $state->lat . ',' . $state->lng, 'markers' => $mapMarkers, 'size' => '640x510', 'zoom' => 5]), ['id' => 'googleMap', 'class' => 'internal zoom-image highslideImage', 'title' => __d('data', 'click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 				} else {
 					$options = [
 						'to' => $state->lat . ',' . $state->lng,
 					];
-					echo $this->Html->link($this->Icon->render('view', [], ['title' => __('Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __('click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
+					echo $this->Html->link($this->Icon->render('view', [], ['title' => __d('data', 'Show')]), $this->GoogleMap->mapUrl($options), ['class' => 'external', 'title' => __d('data', 'click for full map'), 'escapeTitle' => false, 'target' => '_blank']);
 				}
 			}
 
@@ -84,14 +84,14 @@ foreach ($states as $state):
 		<td class="actions">
 			<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $state['id']], ['escapeTitle' => false]); ?>
 
-			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __('Update coordinates')]), ['action' => 'updateCoordinates', $state['id']], ['escapeTitle' => false]); ?>
+			<?php echo $this->Html->link($this->Icon->render('map-o', [], ['title' => __d('data', 'Update coordinates')]), ['action' => 'updateCoordinates', $state['id']], ['escapeTitle' => false]); ?>
 
 			<?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $state['id']], [
 				'escapeTitle' => false,
 				'class' => 'btn btn-link p-0 align-baseline',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $state['id']),
+					'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $state['id']),
 				],
 			]); ?>
 		</td>
@@ -105,10 +105,10 @@ foreach ($states as $state):
 <div class="actions">
 	<ul>
 <?php if (true || $this->AuthUser->hasRole('admin')) { ?>
-		<li><?php echo $this->Html->link(__('Update Coordinates'), ['action' => 'updateCoordinates']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'Update Coordinates'), ['action' => 'updateCoordinates']); ?></li>
 <?php } ?>
-		<li><?php echo $this->Html->link(__('Add State'), ['action' => 'add']); ?></li>
-		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['controller' => 'Countries', 'action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'Add State'), ['action' => 'add']); ?></li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Countries')), ['controller' => 'Countries', 'action' => 'index']); ?> </li>
 	</ul>
 </div>
 <?= $this->element('Data.csp_confirm') ?>

--- a/templates/Admin/States/update_select.php
+++ b/templates/Admin/States/update_select.php
@@ -8,7 +8,7 @@
 use Cake\Core\Configure;
 
 if (!empty($states)) {
-	echo '<option value="">' . Configure::read('Select.default_before') . __($defaultFieldLabel) . Configure::read('Select.default_after') . '</option>';
+	echo '<option value="">' . Configure::read('Select.default_before') . __d('data', $defaultFieldLabel) . Configure::read('Select.default_after') . '</option>';
 	foreach ($states as $k => $v) {
 	echo '<option value="' . $k . '">' . h($v) . '</option>';
 	}
@@ -17,5 +17,5 @@ if (!empty($states)) {
 	if (isset($defaultValue)) {
 		$default = $defaultValue;
 	}
-	echo '<option value="' . $default . '">' . Configure::read('Select.na_before') . __('noOptionAvailable') . Configure::read('Select.na_after') . '</option>';
+	echo '<option value="' . $default . '">' . Configure::read('Select.na_before') . __d('data', 'noOptionAvailable') . Configure::read('Select.na_after') . '</option>';
 }

--- a/templates/Admin/Timezones/add.php
+++ b/templates/Admin/Timezones/add.php
@@ -7,17 +7,17 @@
 <div class="row">
     <aside class="column large-3 medium-4 columns col-sm-4 col-12">
         <ul class="side-nav nav nav-pills flex-column">
-            <li class="nav-item heading"><?= __('Actions') ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('List Timezones'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
+            <li class="nav-item heading"><?= __d('data', 'Actions') ?></li>
+            <li class="nav-item"><?= $this->Html->link(__d('data', 'List Timezones'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
     </aside>
     <div class="column-responsive column-80 form large-9 medium-8 columns col-sm-8 col-12">
         <div class="timezones form content">
-            <h2><?= __('Timezones') ?></h2>
+            <h2><?= __d('data', 'Timezones') ?></h2>
 
             <?= $this->Form->create($timezone) ?>
             <fieldset>
-                <legend><?= __('Add Timezone') ?></legend>
+                <legend><?= __d('data', 'Add Timezone') ?></legend>
                 <?php
                     echo $this->Form->control('name');
                     echo $this->Form->control('country_code');
@@ -31,7 +31,7 @@
 					echo $this->Form->control('notes', ['type' => 'textarea']);
                 ?>
             </fieldset>
-            <?= $this->Form->button(__('Submit')) ?>
+            <?= $this->Form->button(__d('data', 'Submit')) ?>
             <?= $this->Form->end() ?>
         </div>
     </div>

--- a/templates/Admin/Timezones/edit.php
+++ b/templates/Admin/Timezones/edit.php
@@ -7,28 +7,28 @@
 <div class="row">
     <aside class="column large-3 medium-4 columns col-sm-4 col-12">
         <ul class="side-nav nav nav-pills flex-column">
-            <li class="nav-item heading"><?= __('Actions') ?></li>
+            <li class="nav-item heading"><?= __d('data', 'Actions') ?></li>
             <li class="nav-item"><?= $this->Form->postButton(
-                __('Delete'),
+                __d('data', 'Delete'),
                 ['action' => 'delete', $timezone->id],
                 [
                     'class' => 'side-nav-item btn btn-link text-start w-100',
                     'form' => [
                         'class' => 'd-inline',
-                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $timezone->id),
+                        'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $timezone->id),
                     ],
                 ]
                 ) ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('List Timezones'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Html->link(__d('data', 'List Timezones'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
     </aside>
     <div class="column-responsive column-80 form large-9 medium-8 columns col-sm-8 col-12">
         <div class="timezones form content">
-            <h2><?= __('Timezones') ?></h2>
+            <h2><?= __d('data', 'Timezones') ?></h2>
 
             <?= $this->Form->create($timezone) ?>
             <fieldset>
-                <legend><?= __('Edit Timezone') ?></legend>
+                <legend><?= __d('data', 'Edit Timezone') ?></legend>
                 <?php
                     echo $this->Form->control('name');
                     echo $this->Form->control('country_code');
@@ -42,7 +42,7 @@
                     echo $this->Form->control('notes', ['type' => 'textarea']);
                 ?>
             </fieldset>
-            <?= $this->Form->button(__('Submit')) ?>
+            <?= $this->Form->button(__d('data', 'Submit')) ?>
             <?= $this->Form->end() ?>
         </div>
     </div>

--- a/templates/Admin/Timezones/index.php
+++ b/templates/Admin/Timezones/index.php
@@ -9,25 +9,25 @@ use Cake\Core\Plugin;
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
-        <li class="nav-item heading"><?= __('Actions') ?></li>
+        <li class="nav-item heading"><?= __d('data', 'Actions') ?></li>
         <li class="nav-item">
-            <?= $this->Html->link(__('New {0}', __('Timezone')), ['action' => 'add'], ['class' => 'nav-link']) ?>
+            <?= $this->Html->link(__d('data', 'New {0}', __d('data', 'Timezone')), ['action' => 'add'], ['class' => 'nav-link']) ?>
         </li>
 		<li class="nav-item">
-			<?php echo $this->Html->link(__('Sync'), ['action' => 'sync'], ['class' => 'nav-link']); ?>
+			<?php echo $this->Html->link(__d('data', 'Sync'), ['action' => 'sync'], ['class' => 'nav-link']); ?>
 		</li>
     </ul>
 </nav>
 <div class="timezones index content large-9 medium-8 columns col-sm-8 col-12">
 
-	<h2><?= __('Timezones') ?></h2>
+	<h2><?= __d('data', 'Timezones') ?></h2>
 
 	<?php if (Plugin::isLoaded('Search')) { ?>
 		<div class="search-box">
 			<?php
 			echo $this->Form->create(null, ['valueSources' => 'query']);
-			echo $this->Form->control('search', ['placeholder' => __('wildcardSearch {0} and {1}', '*', '?')]);
-			echo $this->Form->button(__('Search'), []);
+			echo $this->Form->control('search', ['placeholder' => __d('data', 'wildcardSearch {0} and {1}', '*', '?')]);
+			echo $this->Form->button(__d('data', 'Search'), []);
 			echo $this->Form->end();
 			?>
 			<?php if ($this->Search->isSearch()) {
@@ -52,7 +52,7 @@ use Cake\Core\Plugin;
                     <th><?= $this->Paginator->sort('notes') ?></th>
                     <th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
                     <th><?= $this->Paginator->sort('modified', null, ['direction' => 'desc']) ?></th>
-                    <th class="actions"><?= __('Actions') ?></th>
+                    <th class="actions"><?= __d('data', 'Actions') ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -87,7 +87,7 @@ use Cake\Core\Plugin;
                             'class' => 'btn btn-link p-0 align-baseline',
                             'form' => [
                                 'class' => 'd-inline',
-                                'data-confirm-message' => __('Are you sure you want to delete # {0}?', $timezone->id),
+                                'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $timezone->id),
                             ],
                         ]); ?>
                     </td>

--- a/templates/Admin/Timezones/link.php
+++ b/templates/Admin/Timezones/link.php
@@ -12,7 +12,7 @@
 
 	<?php echo $this->Form->create(); ?>
 	<fieldset>
-		<legend><?php echo __('Link Timezones');?></legend>
+		<legend><?php echo __d('data', 'Link Timezones');?></legend>
 
 		<?php
 		foreach ($todo as $key => $timezone) {
@@ -26,6 +26,6 @@
 		}
 	?>
 	</fieldset>
-	<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+	<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 
 </div>

--- a/templates/Admin/Timezones/sync.php
+++ b/templates/Admin/Timezones/sync.php
@@ -12,7 +12,7 @@
 
 	<?php echo $this->Form->create(); ?>
 	<fieldset>
-		<legend><?php echo __('Sync Timezones');?></legend>
+		<legend><?php echo __d('data', 'Sync Timezones');?></legend>
 
 		<?php
 		foreach ($diff as $action => $rows) {
@@ -30,6 +30,6 @@
 		}
 	?>
 	</fieldset>
-	<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+	<?php echo $this->Form->submit(__d('data', 'Submit')); echo $this->Form->end();?>
 
 </div>

--- a/templates/Admin/Timezones/view.php
+++ b/templates/Admin/Timezones/view.php
@@ -7,16 +7,16 @@
 <div class="row">
     <aside class="column actions large-3 medium-4 col-sm-4 col-xs-12">
         <ul class="side-nav nav nav-pills flex-column">
-            <li class="nav-item heading"><?= __('Actions') ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('Timezone')), ['action' => 'edit', $timezone->id], ['class' => 'side-nav-item']) ?></li>
-            <li class="nav-item"><?= $this->Form->postButton(__('Delete {0}', __('Timezone')), ['action' => 'delete', $timezone->id], [
+            <li class="nav-item heading"><?= __d('data', 'Actions') ?></li>
+            <li class="nav-item"><?= $this->Html->link(__d('data', 'Edit {0}', __d('data', 'Timezone')), ['action' => 'edit', $timezone->id], ['class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Form->postButton(__d('data', 'Delete {0}', __d('data', 'Timezone')), ['action' => 'delete', $timezone->id], [
                 'class' => 'side-nav-item btn btn-link text-start w-100',
                 'form' => [
                     'class' => 'd-inline',
-                    'data-confirm-message' => __('Are you sure you want to delete # {0}?', $timezone->id),
+                    'data-confirm-message' => __d('data', 'Are you sure you want to delete # {0}?', $timezone->id),
                 ],
             ]) ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('List {0}', __('Timezones')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Html->link(__d('data', 'List {0}', __d('data', 'Timezones')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
     </aside>
     <div class="column-responsive column-80 content large-9 medium-8 col-sm-8 col-xs-12">
@@ -25,7 +25,7 @@
 
             <table class="table table-striped">
                 <tr>
-                    <th><?= __('Name') ?></th>
+                    <th><?= __d('data', 'Name') ?></th>
                     <td>
 						<?= h($timezone->name) ?>
 						<div><small>
@@ -36,50 +36,50 @@
 					</td>
                 </tr>
                 <tr>
-                    <th><?= __('Country Code') ?></th>
+                    <th><?= __d('data', 'Country Code') ?></th>
                     <td><?php
 						echo $timezone->country ? $this->Html->link($timezone->country_code, ['controller' => 'Countries', 'action' => 'view', $timezone->country->id]) : h($timezone->country_code)
 					?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Offset') ?></th>
+                    <th><?= __d('data', 'Offset') ?></th>
                     <td><?= h($timezone->offset_string) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Offset Dst') ?></th>
+                    <th><?= __d('data', 'Offset Dst') ?></th>
                     <td><?= h($timezone->offset_dst_string) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Type') ?></th>
+                    <th><?= __d('data', 'Type') ?></th>
                     <td><?= h($timezone->type) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Covered') ?></th>
+                    <th><?= __d('data', 'Covered') ?></th>
                     <td><?= h($timezone->covered) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Notes') ?></th>
+                    <th><?= __d('data', 'Notes') ?></th>
                     <td><?= h($timezone->notes) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Lat') ?></th>
+                    <th><?= __d('data', 'Lat') ?></th>
                     <td><?= $this->Number->format($timezone->lat) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Lng') ?></th>
+                    <th><?= __d('data', 'Lng') ?></th>
                     <td><?= $this->Number->format($timezone->lng) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Created') ?></th>
+                    <th><?= __d('data', 'Created') ?></th>
                     <td><?= $this->Time->nice($timezone->created) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Modified') ?></th>
+                    <th><?= __d('data', 'Modified') ?></th>
                     <td><?= $this->Time->nice($timezone->modified) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Active') ?></th>
-                    <td><?= $this->Format->yesNo($timezone->active) ?> <?= $timezone->active ? __('Yes') : __('No'); ?></td>
+                    <th><?= __d('data', 'Active') ?></th>
+                    <td><?= $this->Format->yesNo($timezone->active) ?> <?= $timezone->active ? __d('data', 'Yes') : __d('data', 'No'); ?></td>
                 </tr>
             </table>
         </div>

--- a/templates/Continents/index.php
+++ b/templates/Continents/index.php
@@ -6,12 +6,12 @@
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
 	<ul class="side-nav nav nav-pills flex-column">
-		<li class="nav-item heading"><?= __('Actions') ?></li>
+		<li class="nav-item heading"><?= __d('data', 'Actions') ?></li>
 	</ul>
 </nav>
 <div class="cities index content large-9 medium-8 columns col-sm-8 col-12">
 
-	<h1><?= __('Continents') ?></h1>
+	<h1><?= __d('data', 'Continents') ?></h1>
 
 	<div class="tree">
 		<?php echo $this->Tree->generate($continents); ?>

--- a/templates/Countries/index.php
+++ b/templates/Countries/index.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div class="page index">
-<h2><?php echo __('Countries');?></h2>
+<h2><?php echo __d('data', 'Countries');?></h2>
 
 <table class="table">
 <tr>
@@ -45,16 +45,16 @@ foreach ($countries as $country):
 <?php echo $this->element('Tools.pagination'); ?>
 </div>
 
-<?php if (__('countryCodeExplanation') !== 'countryCodeExplanation') { ?>
+<?php if (__d('data', 'countryCodeExplanation') !== 'countryCodeExplanation') { ?>
 <br/>
-<?php echo __('Note') ?>:
+<?php echo __d('data', 'Note') ?>:
 <ul>
-<li><?php echo __('countryCodeExplanation')?></li>
+<li><?php echo __d('data', 'countryCodeExplanation')?></li>
 </ul>
 <?php } ?>
 
 <br/>
-<span class="keyList"><?php echo __('Legend');?></span>
+<span class="keyList"><?php echo __d('data', 'Legend');?></span>
 <ul class="keyList">
 <li><?php echo $this->Data->countryIcon(null); ?> = Default Icon</li>
 </ul>

--- a/templates/Currencies/index.php
+++ b/templates/Currencies/index.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div class="currencies index content large-9 medium-8 columns col-12">
-    <h1><?= __('Currencies') ?></h1>
+    <h1><?= __d('data', 'Currencies') ?></h1>
 
     <div class="">
         <table class="table table-sm table-striped">

--- a/templates/PostalCodes/map.php
+++ b/templates/PostalCodes/map.php
@@ -16,10 +16,10 @@ $this->Html->script($this->GoogleMap->apiUrl(), ['inline' => false])?>
 <div>
 <?php echo $this->Form->create(null);?>
 	<fieldset>
-		<legend><?php echo __('Search {0}', __('Area Code')); ?></legend>
+		<legend><?php echo __d('data', 'Search {0}', __d('data', 'Area Code')); ?></legend>
 	<?php
 		echo $this->Form->control('code');
-		echo $this->Form->submit(__('Submit'));
+		echo $this->Form->submit(__d('data', 'Submit'));
 	?>
 	</fieldset>
 <?php echo $this->Form->end();?>

--- a/templates/States/index.php
+++ b/templates/States/index.php
@@ -15,7 +15,7 @@ use Cake\Core\Plugin;
 		</div>
 	<?php } ?>
 
-<h2><?php echo __('States');?></h2>
+<h2><?php echo __d('data', 'States');?></h2>
 
 <table class="table">
 <tr>
@@ -23,7 +23,7 @@ use Cake\Core\Plugin;
 	<th><?php echo $this->Paginator->sort('name');?></th>
 	<th><?php echo $this->Paginator->sort('ori_name');?></th>
 	<th><?php echo $this->Paginator->sort('code');?></th>
-	<th><?php echo __('Coordinates');?></th>
+	<th><?php echo __d('data', 'Coordinates');?></th>
 </tr>
 <?php
 /** @var \Data\Model\Entity\State[] $states */
@@ -64,6 +64,6 @@ foreach ($states as $state):
 
 <div class="actions">
 	<ul>
-		<li><?php echo $this->Html->link(__('List {0}', __('Countries')), ['controller' => 'Countries', 'action' => 'index']); ?> </li>
+		<li><?php echo $this->Html->link(__d('data', 'List {0}', __d('data', 'Countries')), ['controller' => 'Countries', 'action' => 'index']); ?> </li>
 	</ul>
 </div>

--- a/templates/States/update_select.php
+++ b/templates/States/update_select.php
@@ -8,7 +8,7 @@
 use Cake\Core\Configure;
 
 if (!empty($states)) {
-	echo '<option value="">' . Configure::read('Select.default_before') . __($defaultFieldLabel) . Configure::read('Select.default_after') . '</option>';
+	echo '<option value="">' . Configure::read('Select.default_before') . __d('data', $defaultFieldLabel) . Configure::read('Select.default_after') . '</option>';
 	foreach ($states as $k => $v) {
 	echo '<option value="' . $k . '">' . h($v) . '</option>';
 	}
@@ -17,5 +17,5 @@ if (!empty($states)) {
 	if (isset($defaultValue)) {
 		$default = $defaultValue;
 	}
-	echo '<option value="' . $default . '">' . Configure::read('Select.na_before') . __('noOptionAvailable') . Configure::read('Select.na_after') . '</option>';
+	echo '<option value="' . $default . '">' . Configure::read('Select.na_before') . __d('data', 'noOptionAvailable') . Configure::read('Select.na_after') . '</option>';
 }

--- a/templates/Timezones/index.php
+++ b/templates/Timezones/index.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div class="timezones index content large-9 medium-8 columns col-12">
-    <h1><?= __('Timezones') ?></h1>
+    <h1><?= __d('data', 'Timezones') ?></h1>
 
     <div class="">
         <table class="table table-sm table-striped">
@@ -17,7 +17,7 @@
                     <th><?= $this->Paginator->sort('offset_dst') ?></th>
                     <th><?= $this->Paginator->sort('type') ?></th>
                     <th><?= $this->Paginator->sort('active') ?></th>
-					<th><?php echo __('Coordinates');?></th>
+					<th><?php echo __d('data', 'Coordinates');?></th>
                     <th><?= $this->Paginator->sort('covered') ?></th>
                     <th><?= $this->Paginator->sort('notes') ?></th>
                 </tr>

--- a/templates/element/States/search.php
+++ b/templates/element/States/search.php
@@ -8,18 +8,18 @@
  * @var \App\View\AppView $this
  */
 echo $this->Form->create(null, ['valueSources' => 'query']); ?>
-<?php echo __('Country');?>:&nbsp;&nbsp;
+<?php echo __d('data', 'Country');?>:&nbsp;&nbsp;
 <?php echo $this->Form->control('country_id', [
 	'class' => 'filter',
 	'label' => false,
 	'div' => false,
 	'type' => 'select',
-	'empty' => ['' => '- [ ' . __('noRestriction') . ' ] -'],
+	'empty' => ['' => '- [ ' . __d('data', 'noRestriction') . ' ] -'],
 	'options' => $countries]
 ); ?>
-<?php echo $this->Form->control('search', ['placeholder' => __('wildcardSearch {0} and {1}', '*', '?')]); ?>
+<?php echo $this->Form->control('search', ['placeholder' => __d('data', 'wildcardSearch {0} and {1}', '*', '?')]); ?>
 
-<?php echo $this->Form->button(__('Search'), ['div' => false]); ?>
+<?php echo $this->Form->button(__d('data', 'Search'), ['div' => false]); ?>
 <?php if ($this->Search->isSearch()) {
 	echo $this->Search->resetLink(null, ['class' => 'btn btn-secondary']);
 } ?>


### PR DESCRIPTION
## Summary

- Convert 536 `__()` calls across `src/` and `templates/` to `__d('data', ...)` so plugin strings live in their own domain.
- Add `resources/locales/data.pot` (194 unique msgids) generated via `bin/cake i18n extract` so language packs can be derived from a stable POT.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 102 / 102 (4 pre-existing notices, 4 skipped, 1 incomplete — unrelated to this change)
- phpstan: no errors
- phpcs: clean