### PR TITLE
Fix MimeTest stale URL and add network-skip guard

### DIFF
--- a/tests/TestCase/Utility/MimeTest.php
+++ b/tests/TestCase/Utility/MimeTest.php
@@ -98,16 +98,30 @@ class MimeTest extends TestCase {
 	 * @return void
 	 */
 	public function testgetMimeTypeByAlias() {
-		$res = $this->Mime->detectMimeType('https://raw.githubusercontent.com/dereuromark/cakephp-ide-helper/master/docs/img/code_completion.png');
-		$this->assertEquals('image/png', $res);
+		// docs/img/* moved to docs/public/img/* in cakephp-ide-helper a while back; the
+		// previous URL silently 404'd and emptied the response. Use the live path.
+		$validUrl = 'https://raw.githubusercontent.com/dereuromark/cakephp-ide-helper/master/docs/public/img/code_completion.png';
+		$invalidUrl = 'https://raw.githubusercontent.com/dereuromark/cakephp-ide-helper/master/docs/public/img/code_completion_does_not_exist.png';
 
-		$res = $this->Mime->detectMimeType('https://raw.githubusercontent.com/dereuromark/cakephp-ide-helper/master/docs/img/code_completion_invalid.png');
-		$this->assertEquals('', $res);
+		// Network sanity probe so this test skips cleanly when the runner cannot reach
+		// raw.githubusercontent.com, instead of erroring out and turning the suite red.
+		// We only probe the invalid URL (cheap 404 round-trip) — if that returns headers,
+		// the host is reachable and the assertions below are meaningful.
+		$probe = @get_headers($invalidUrl, false, stream_context_create(['http' => ['timeout' => 3]]));
+		if ($probe === false) {
+			$this->markTestSkipped('raw.githubusercontent.com not reachable from this runner.');
+		}
+
+		$res = $this->Mime->detectMimeType($validUrl);
+		$this->assertSame('image/png', $res);
+
+		$res = $this->Mime->detectMimeType($invalidUrl);
+		$this->assertSame('', $res);
 
 		$file = Plugin::path('Data') . 'tests' . DS . 'test_files' . DS . 'json' . DS . 'bitcoincharts.json';
 		$this->assertFileExists($file);
 		$res = $this->Mime->detectMimeType($file);
-		$this->assertEquals('application/json', $res);
+		$this->assertSame('application/json', $res);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `testgetMimeTypeByAlias` has been red on every CI matrix entry because the github raw URL it referenced (`docs/img/code_completion.png`) 404'd after cakephp-ide-helper restructured its docs into `docs/public/img/*`. The Mime utility correctly returned an empty string for the dead URL, but the test asserted `image/png`, so the suite stayed red.
- Updates both URLs (the valid and the deliberately-invalid one) to the live `docs/public/img/` path.
- Adds a tiny `get_headers` probe so the test skips cleanly when the runner cannot reach `raw.githubusercontent.com`, instead of erroring and turning the suite red on a transient network glitch the test was never designed to detect.
- Tightens `assertEquals` to `assertSame` in passing — these are scalar string comparisons.

This is the only thing standing between master CI and a fully green run, and it's blocking the CI on #24 and #25 from being clearly readable. Filing as a tightly-scoped fix so it can land independently.