### PR TITLE
Adopt TEntity table template + tighten Table/Entity method annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
 	},
 	"require": {
 		"php": ">=8.2",
-		"cakephp/cakephp": "^5.1.1",
-		"dereuromark/cakephp-shim": "^3.1.0",
-		"dereuromark/cakephp-tools": "^3.9.2"
+		"cakephp/cakephp": "^5.3.4",
+		"dereuromark/cakephp-shim": "^3.9.0",
+		"dereuromark/cakephp-tools": "^3.12.8"
 	},
 	"require-dev": {
 		"cakephp/migrations": "^5.0.0",

--- a/src/Model/Entity/Continent.php
+++ b/src/Model/Entity/Continent.php
@@ -15,8 +15,8 @@ use Tools\Model\Entity\Entity;
  * @property int $status
  * @property \Cake\I18n\DateTime $modified
  * @property \Data\Model\Entity\Continent|null $parent_continent
- * @property array<\Cake\ORM\Entity> $child_continents
- * @property array<\Cake\ORM\Entity> $countries
+ * @property array<\Data\Model\Entity\Continent> $child_continents
+ * @property array<\Data\Model\Entity\Country> $countries
  */
 class Continent extends Entity {
 

--- a/src/Model/Table/CitiesTable.php
+++ b/src/Model/Table/CitiesTable.php
@@ -6,22 +6,24 @@ use Cake\Core\Configure;
 use Tools\Model\Table\Table;
 
 /**
- * @property \Data\Model\Table\CountriesTable|\Cake\ORM\Association\BelongsTo $Countries
- *
+ * @extends \Tools\Model\Table\Table<array{Slugged: \Tools\Model\Behavior\SluggedBehavior}, \Data\Model\Entity\City>
+ * @property \Cake\ORM\Association\BelongsTo<\Data\Model\Table\CountriesTable> $Countries
  * @method \Data\Model\Entity\City newEmptyEntity()
  * @method \Data\Model\Entity\City newEntity(array $data, array $options = [])
  * @method array<\Data\Model\Entity\City> newEntities(array $data, array $options = [])
  * @method \Data\Model\Entity\City get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \Data\Model\Entity\City findOrCreate($search, ?callable $callback = null, array $options = [])
- * @method \Data\Model\Entity\City patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method array<\Data\Model\Entity\City> patchEntities(iterable $entities, array $data, array $options = [])
- * @method \Data\Model\Entity\City|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Data\Model\Entity\City saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\City>|false saveMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\City> saveManyOrFail(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\City>|false deleteMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\City> deleteManyOrFail(iterable $entities, array $options = [])
- *
+ * @method \Data\Model\Entity\City findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
+ * @method \Data\Model\Entity\City patchEntity(\Data\Model\Entity\City $entity, array $data, array $options = [])
+ * @method array<\Data\Model\Entity\City> patchEntities(iterable<\Data\Model\Entity\City> $entities, array $data, array $options = [])
+ * @method \Data\Model\Entity\City|false save(\Data\Model\Entity\City $entity, array $options = [])
+ * @method \Data\Model\Entity\City saveOrFail(\Data\Model\Entity\City $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\City>|false saveMany(iterable<\Data\Model\Entity\City> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\City> saveManyOrFail(iterable<\Data\Model\Entity\City> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\City>|false deleteMany(iterable<\Data\Model\Entity\City> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\City> deleteManyOrFail(iterable<\Data\Model\Entity\City> $entities, array $options = [])
+ * @method bool delete(\Data\Model\Entity\City $entity, array $options = [])
+ * @method bool deleteOrFail(\Data\Model\Entity\City $entity, array $options = [])
+ * @method \Data\Model\Entity\City|array<\Data\Model\Entity\City> loadInto(\Data\Model\Entity\City|array<\Data\Model\Entity\City> $entities, array $contain)
  * @mixin \Tools\Model\Behavior\SluggedBehavior
  */
 class CitiesTable extends Table {

--- a/src/Model/Table/ContinentsTable.php
+++ b/src/Model/Table/ContinentsTable.php
@@ -7,22 +7,26 @@ use Cake\Event\EventInterface;
 use Tools\Model\Table\Table;
 
 /**
- * @property \Data\Model\Table\ContinentsTable|\Cake\ORM\Association\BelongsTo $ParentContinents
- * @property \Cake\ORM\Table|\Cake\ORM\Association\HasMany $ChildContinents
- * @property \Cake\ORM\Table|\Cake\ORM\Association\HasMany $Countries
+ * @extends \Tools\Model\Table\Table<array{Tree: \Cake\ORM\Behavior\TreeBehavior}, \Data\Model\Entity\Continent>
+ * @property \Cake\ORM\Association\BelongsTo<\Data\Model\Table\ContinentsTable> $ParentContinents
+ * @property \Cake\ORM\Association\HasMany<\Data\Model\Table\ContinentsTable> $ChildContinents
+ * @property \Cake\ORM\Association\HasMany<\Data\Model\Table\CountriesTable> $Countries
  * @method \Data\Model\Entity\Continent newEmptyEntity()
  * @method \Data\Model\Entity\Continent newEntity(array $data, array $options = [])
  * @method array<\Data\Model\Entity\Continent> newEntities(array $data, array $options = [])
  * @method \Data\Model\Entity\Continent get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \Data\Model\Entity\Continent findOrCreate($search, ?callable $callback = null, array $options = [])
- * @method \Data\Model\Entity\Continent patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method array<\Data\Model\Entity\Continent> patchEntities(iterable $entities, array $data, array $options = [])
- * @method \Data\Model\Entity\Continent|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Data\Model\Entity\Continent saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Continent>|false saveMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Continent> saveManyOrFail(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Continent>|false deleteMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Continent> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Data\Model\Entity\Continent findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
+ * @method \Data\Model\Entity\Continent patchEntity(\Data\Model\Entity\Continent $entity, array $data, array $options = [])
+ * @method array<\Data\Model\Entity\Continent> patchEntities(iterable<\Data\Model\Entity\Continent> $entities, array $data, array $options = [])
+ * @method \Data\Model\Entity\Continent|false save(\Data\Model\Entity\Continent $entity, array $options = [])
+ * @method \Data\Model\Entity\Continent saveOrFail(\Data\Model\Entity\Continent $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Continent>|false saveMany(iterable<\Data\Model\Entity\Continent> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Continent> saveManyOrFail(iterable<\Data\Model\Entity\Continent> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Continent>|false deleteMany(iterable<\Data\Model\Entity\Continent> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Continent> deleteManyOrFail(iterable<\Data\Model\Entity\Continent> $entities, array $options = [])
+ * @method bool delete(\Data\Model\Entity\Continent $entity, array $options = [])
+ * @method bool deleteOrFail(\Data\Model\Entity\Continent $entity, array $options = [])
+ * @method \Data\Model\Entity\Continent|array<\Data\Model\Entity\Continent> loadInto(\Data\Model\Entity\Continent|array<\Data\Model\Entity\Continent> $entities, array $contain)
  * @mixin \Cake\ORM\Behavior\TreeBehavior
  */
 class ContinentsTable extends Table {

--- a/src/Model/Table/CountriesTable.php
+++ b/src/Model/Table/CountriesTable.php
@@ -12,22 +12,26 @@ use InvalidArgumentException;
 use Tools\Model\Table\Table;
 
 /**
- * @property \Data\Model\Table\ContinentsTable|\Cake\ORM\Association\BelongsTo $Continents
- * @property \Data\Model\Table\StatesTable|\Cake\ORM\Association\HasMany $States
- * @property \Data\Model\Table\TimezonesTable|\Cake\ORM\Association\HasMany $Timezones
+ * @extends \Tools\Model\Table\Table<array{Search: \Search\Model\Behavior\SearchBehavior}, \Data\Model\Entity\Country>
+ * @property \Cake\ORM\Association\BelongsTo<\Data\Model\Table\ContinentsTable> $Continents
+ * @property \Cake\ORM\Association\HasMany<\Data\Model\Table\StatesTable> $States
+ * @property \Cake\ORM\Association\HasMany<\Data\Model\Table\TimezonesTable> $Timezones
  * @method \Data\Model\Entity\Country get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \Data\Model\Entity\Country newEntity(array $data, array $options = [])
  * @method array<\Data\Model\Entity\Country> newEntities(array $data, array $options = [])
- * @method \Data\Model\Entity\Country|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Data\Model\Entity\Country patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method array<\Data\Model\Entity\Country> patchEntities(iterable $entities, array $data, array $options = [])
- * @method \Data\Model\Entity\Country findOrCreate($search, ?callable $callback = null, array $options = [])
- * @method \Data\Model\Entity\Country saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
+ * @method \Data\Model\Entity\Country|false save(\Data\Model\Entity\Country $entity, array $options = [])
+ * @method \Data\Model\Entity\Country patchEntity(\Data\Model\Entity\Country $entity, array $data, array $options = [])
+ * @method array<\Data\Model\Entity\Country> patchEntities(iterable<\Data\Model\Entity\Country> $entities, array $data, array $options = [])
+ * @method \Data\Model\Entity\Country findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
+ * @method \Data\Model\Entity\Country saveOrFail(\Data\Model\Entity\Country $entity, array $options = [])
  * @method \Data\Model\Entity\Country newEmptyEntity()
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Country>|false saveMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Country> saveManyOrFail(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Country>|false deleteMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Country> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Country>|false saveMany(iterable<\Data\Model\Entity\Country> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Country> saveManyOrFail(iterable<\Data\Model\Entity\Country> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Country>|false deleteMany(iterable<\Data\Model\Entity\Country> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Country> deleteManyOrFail(iterable<\Data\Model\Entity\Country> $entities, array $options = [])
+ * @method bool delete(\Data\Model\Entity\Country $entity, array $options = [])
+ * @method bool deleteOrFail(\Data\Model\Entity\Country $entity, array $options = [])
+ * @method \Data\Model\Entity\Country|array<\Data\Model\Entity\Country> loadInto(\Data\Model\Entity\Country|array<\Data\Model\Entity\Country> $entities, array $contain)
  * @mixin \Search\Model\Behavior\SearchBehavior
  */
 class CountriesTable extends Table {

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -19,19 +19,23 @@ use Tools\Model\Table\Table;
  * for details see
  * http://www.loc.gov/standards/iso639-2/php/code_list.php
  *
+ * @extends \Tools\Model\Table\Table<array{Search: \Search\Model\Behavior\SearchBehavior}, \Data\Model\Entity\Language>
  * @method \Data\Model\Entity\Language get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \Data\Model\Entity\Language newEntity(array $data, array $options = [])
  * @method array<\Data\Model\Entity\Language> newEntities(array $data, array $options = [])
- * @method \Data\Model\Entity\Language|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Data\Model\Entity\Language patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method array<\Data\Model\Entity\Language> patchEntities(iterable $entities, array $data, array $options = [])
- * @method \Data\Model\Entity\Language findOrCreate($search, ?callable $callback = null, array $options = [])
- * @method \Data\Model\Entity\Language saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
+ * @method \Data\Model\Entity\Language|false save(\Data\Model\Entity\Language $entity, array $options = [])
+ * @method \Data\Model\Entity\Language patchEntity(\Data\Model\Entity\Language $entity, array $data, array $options = [])
+ * @method array<\Data\Model\Entity\Language> patchEntities(iterable<\Data\Model\Entity\Language> $entities, array $data, array $options = [])
+ * @method \Data\Model\Entity\Language findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
+ * @method \Data\Model\Entity\Language saveOrFail(\Data\Model\Entity\Language $entity, array $options = [])
  * @method \Data\Model\Entity\Language newEmptyEntity()
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Language>|false saveMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Language> saveManyOrFail(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Language>|false deleteMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Language> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Language>|false saveMany(iterable<\Data\Model\Entity\Language> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Language> saveManyOrFail(iterable<\Data\Model\Entity\Language> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Language>|false deleteMany(iterable<\Data\Model\Entity\Language> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Language> deleteManyOrFail(iterable<\Data\Model\Entity\Language> $entities, array $options = [])
+ * @method bool delete(\Data\Model\Entity\Language $entity, array $options = [])
+ * @method bool deleteOrFail(\Data\Model\Entity\Language $entity, array $options = [])
+ * @method \Data\Model\Entity\Language|array<\Data\Model\Entity\Language> loadInto(\Data\Model\Entity\Language|array<\Data\Model\Entity\Language> $entities, array $contain)
  * @mixin \Search\Model\Behavior\SearchBehavior
  */
 class LanguagesTable extends Table {

--- a/src/Model/Table/StatesTable.php
+++ b/src/Model/Table/StatesTable.php
@@ -12,21 +12,25 @@ use Geo\Geocoder\Geocoder;
 use Tools\Model\Table\Table;
 
 /**
+ * @extends \Tools\Model\Table\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Slugged: \Tools\Model\Behavior\SluggedBehavior}, \Data\Model\Entity\State>
  * @property \Cake\ORM\Association\BelongsTo<\Data\Model\Table\CountriesTable> $Countries
  * @property \Data\Model\Table\CountiesTable|\Cake\ORM\Association\HasMany $Counties
  * @method \Data\Model\Entity\State get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \Data\Model\Entity\State newEntity(array $data, array $options = [])
  * @method array<\Data\Model\Entity\State> newEntities(array $data, array $options = [])
- * @method \Data\Model\Entity\State|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Data\Model\Entity\State saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Data\Model\Entity\State patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method array<\Data\Model\Entity\State> patchEntities(iterable $entities, array $data, array $options = [])
- * @method \Data\Model\Entity\State findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \Data\Model\Entity\State|false save(\Data\Model\Entity\State $entity, array $options = [])
+ * @method \Data\Model\Entity\State saveOrFail(\Data\Model\Entity\State $entity, array $options = [])
+ * @method \Data\Model\Entity\State patchEntity(\Data\Model\Entity\State $entity, array $data, array $options = [])
+ * @method array<\Data\Model\Entity\State> patchEntities(iterable<\Data\Model\Entity\State> $entities, array $data, array $options = [])
+ * @method \Data\Model\Entity\State findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \Data\Model\Entity\State newEmptyEntity()
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\State>|false saveMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\State> saveManyOrFail(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\State>|false deleteMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\State> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\State>|false saveMany(iterable<\Data\Model\Entity\State> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\State> saveManyOrFail(iterable<\Data\Model\Entity\State> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\State>|false deleteMany(iterable<\Data\Model\Entity\State> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\State> deleteManyOrFail(iterable<\Data\Model\Entity\State> $entities, array $options = [])
+ * @method bool delete(\Data\Model\Entity\State $entity, array $options = [])
+ * @method bool deleteOrFail(\Data\Model\Entity\State $entity, array $options = [])
+ * @method \Data\Model\Entity\State|array<\Data\Model\Entity\State> loadInto(\Data\Model\Entity\State|array<\Data\Model\Entity\State> $entities, array $contain)
  * @mixin \Search\Model\Behavior\SearchBehavior
  * @mixin \Tools\Model\Behavior\SluggedBehavior
  */

--- a/src/Model/Table/TimezonesTable.php
+++ b/src/Model/Table/TimezonesTable.php
@@ -14,21 +14,25 @@ use RuntimeException;
 /**
  * Timezones Model
  *
- * @property \Data\Model\Table\TimezonesTable|\Cake\ORM\Association\BelongsTo $CanonicalTimezones
- * @property \Data\Model\Table\CountriesTable|\Cake\ORM\Association\BelongsTo $Countries
+ * @extends \Cake\ORM\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \Data\Model\Entity\Timezone>
+ * @property \Cake\ORM\Association\BelongsTo<\Data\Model\Table\TimezonesTable> $CanonicalTimezones
+ * @property \Cake\ORM\Association\BelongsTo<\Data\Model\Table\CountriesTable> $Countries
  * @method \Data\Model\Entity\Timezone newEmptyEntity()
  * @method \Data\Model\Entity\Timezone newEntity(array $data, array $options = [])
  * @method array<\Data\Model\Entity\Timezone> newEntities(array $data, array $options = [])
  * @method \Data\Model\Entity\Timezone get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \Data\Model\Entity\Timezone findOrCreate($search, ?callable $callback = null, array $options = [])
- * @method \Data\Model\Entity\Timezone patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method array<\Data\Model\Entity\Timezone> patchEntities(iterable $entities, array $data, array $options = [])
- * @method \Data\Model\Entity\Timezone|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Data\Model\Entity\Timezone saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Timezone>|false saveMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Timezone> saveManyOrFail(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Timezone>|false deleteMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Timezone> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Data\Model\Entity\Timezone findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
+ * @method \Data\Model\Entity\Timezone patchEntity(\Data\Model\Entity\Timezone $entity, array $data, array $options = [])
+ * @method array<\Data\Model\Entity\Timezone> patchEntities(iterable<\Data\Model\Entity\Timezone> $entities, array $data, array $options = [])
+ * @method \Data\Model\Entity\Timezone|false save(\Data\Model\Entity\Timezone $entity, array $options = [])
+ * @method \Data\Model\Entity\Timezone saveOrFail(\Data\Model\Entity\Timezone $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Timezone>|false saveMany(iterable<\Data\Model\Entity\Timezone> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Timezone> saveManyOrFail(iterable<\Data\Model\Entity\Timezone> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Timezone>|false deleteMany(iterable<\Data\Model\Entity\Timezone> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Data\Model\Entity\Timezone> deleteManyOrFail(iterable<\Data\Model\Entity\Timezone> $entities, array $options = [])
+ * @method bool delete(\Data\Model\Entity\Timezone $entity, array $options = [])
+ * @method bool deleteOrFail(\Data\Model\Entity\Timezone $entity, array $options = [])
+ * @method \Data\Model\Entity\Timezone|array<\Data\Model\Entity\Timezone> loadInto(\Data\Model\Entity\Timezone|array<\Data\Model\Entity\Timezone> $entities, array $contain)
  * @mixin \Search\Model\Behavior\SearchBehavior
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */


### PR DESCRIPTION
## Summary

Re-runs the latest `dereuromark/cakephp-ide-helper` model annotator on the plugin's tables. The output adds the second `TEntity` template parameter on every Table's `@extends` declaration, and tightens the `patchEntity` / `save` / `saveMany` / `loadInto` / `delete` method signatures from generic `EntityInterface` to the concrete `Data\Model\Entity\*` classes.

This lets PHPStan flow the entity type end-to-end through `find()->first()` and `find()->toArray()` chains in downstream code, removing the inline `@var` annotations consumer apps currently sprinkle on every callsite.

## Version floor

| Dependency | Before | After | Why |
|---|---|---|---|
| `cakephp/cakephp` | `^5.1.1` | `^5.3.4` | Introduces the second `TEntity` template on `Cake\ORM\Table` |
| `dereuromark/cakephp-tools` | `^3.9.2` | `^3.12.8` | Matching template propagation in `Tools\Model\Table\Table` |
| `dereuromark/cakephp-shim` | `^3.1.0` | `^3.9.0` | Same, in `Shim\Model\Table\Table` |

Older versions of any of these would surface a `generics.moreTypes` error from PHPStan (`Cake\ORM\Table supports only 1 template type`).

## Notes on the annotator output

- Association `@property` lines kept as `\Cake\ORM\Association\BelongsTo<\Data\Model\Table\CountriesTable>` (the proper PHPDoc generic form, already used on most lines on master) rather than the `&` intersection the raw annotator emits. The intersection form would require pulling in `cakedc/cakephp-phpstan` to resolve `propertyTag.unresolvableType` — out of scope here.
- A handful of Entity property updates were scrubbed where the annotator inferred them from a consumer app's MySQL schema rather than the plugin's own migrations (notably `City::$merged_to_id` / `$visits` and `Country::$modified` nullability shifts).

## Verification

- `composer stan` clean (PHPStan level 8)
- `composer cs-check` clean
- Plugin tests still pass on PHP 8.4 / Cake 5.3.5
