### PR TITLE
Honor camelCase Country.imagePath in country controllers

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -54,11 +54,7 @@ return [
 		'iconFontClass' => null, // e.g. 'flag-icon'
 		// Custom path for country flag images. Plugin-dotted paths are supported,
 		// e.g. 'MyPlugin./img/country_flags/'. Null uses the bundled Data flags.
-		// NOTE: DataHelper reads camelCase `imagePath`, but CountriesController and
-		// Admin/CountriesController read snake_case `image_path`. Set BOTH to the same
-		// value until the source is unified, or the admin flag pages will ignore it.
 		'imagePath' => null,
-		'image_path' => null, // Read by Countries / Admin Countries controllers (see note)
 	],
 
 	// Language flag display options (read by DataHelper).

--- a/src/Controller/Admin/CountriesController.php
+++ b/src/Controller/Admin/CountriesController.php
@@ -53,7 +53,7 @@ class CountriesController extends DataAppController {
 	public function beforeFilter(EventInterface $event): void {
 		parent::beforeFilter($event);
 
-		$specific = Configure::read('Country.image_path');
+		$specific = Configure::read('Country.imagePath') ?? Configure::read('Country.image_path');
 		if ($specific) {
 			$this->imageFolder = WWW_ROOT . 'img' . DS . $specific . DS;
 		} else {

--- a/src/Controller/CountriesController.php
+++ b/src/Controller/CountriesController.php
@@ -49,7 +49,7 @@ class CountriesController extends DataAppController {
 	public function beforeFilter(EventInterface $event): void {
 		parent::beforeFilter($event);
 
-		$specific = Configure::read('Country.image_path');
+		$specific = Configure::read('Country.imagePath') ?? Configure::read('Country.image_path');
 		if ($specific) {
 			$this->imageFolder = WWW_ROOT . 'img' . DS . $specific . DS;
 		} else {

--- a/tests/TestCase/Controller/Admin/CountriesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/CountriesControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Data\Test\TestCase\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -57,6 +58,39 @@ class CountriesControllerTest extends TestCase {
 
 		$this->get(['prefix' => 'Admin', 'plugin' => 'Data', 'controller' => 'Countries', 'action' => 'view', 1]);
 		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * The camelCase `Country.imagePath` key must be honored and take precedence
+	 * over the snake_case `Country.image_path` BC fallback.
+	 *
+	 * @return void
+	 */
+	public function testImagePathHonorsCamelCaseKey() {
+		$imagePath = 'Data./img/country_flags/';
+		Configure::write('Country.imagePath', $imagePath);
+		Configure::write('Country.image_path', 'legacy_flags');
+
+		$this->disableErrorHandlerMiddleware();
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Data', 'controller' => 'Countries', 'action' => 'index']);
+		$this->assertResponseCode(200);
+
+		$this->assertSame(WWW_ROOT . 'img' . DS . $imagePath . DS, $this->_controller->imageFolder);
+	}
+
+	/**
+	 * The snake_case `Country.image_path` key remains supported as a BC fallback.
+	 *
+	 * @return void
+	 */
+	public function testImagePathBcFallback() {
+		Configure::write('Country.image_path', 'legacy_flags');
+
+		$this->disableErrorHandlerMiddleware();
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Data', 'controller' => 'Countries', 'action' => 'index']);
+		$this->assertResponseCode(200);
+
+		$this->assertSame(WWW_ROOT . 'img' . DS . 'legacy_flags' . DS, $this->_controller->imageFolder);
 	}
 
 }

--- a/tests/TestCase/Controller/CountriesControllerTest.php
+++ b/tests/TestCase/Controller/CountriesControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace Data\Test\TestCase\Controller;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use ReflectionProperty;
 
 /**
  * @uses \Data\Controller\CountriesController
@@ -36,6 +38,39 @@ class CountriesControllerTest extends TestCase {
 
 		$this->get(['plugin' => 'Data', 'controller' => 'Countries', 'action' => 'index']);
 		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * The camelCase `Country.imagePath` key must be honored by the controller.
+	 *
+	 * @return void
+	 */
+	public function testImagePathHonorsCamelCaseKey() {
+		$imagePath = 'Data./img/country_flags/';
+		Configure::write('Country.imagePath', $imagePath);
+
+		$this->disableErrorHandlerMiddleware();
+		$this->get(['plugin' => 'Data', 'controller' => 'Countries', 'action' => 'index']);
+		$this->assertResponseCode(200);
+
+		$property = new ReflectionProperty($this->_controller, 'imageFolder');
+		$this->assertSame(WWW_ROOT . 'img' . DS . $imagePath . DS, $property->getValue($this->_controller));
+	}
+
+	/**
+	 * The snake_case `Country.image_path` key remains supported as a BC fallback.
+	 *
+	 * @return void
+	 */
+	public function testImagePathBcFallback() {
+		Configure::write('Country.image_path', 'legacy_flags');
+
+		$this->disableErrorHandlerMiddleware();
+		$this->get(['plugin' => 'Data', 'controller' => 'Countries', 'action' => 'index']);
+		$this->assertResponseCode(200);
+
+		$property = new ReflectionProperty($this->_controller, 'imageFolder');
+		$this->assertSame(WWW_ROOT . 'img' . DS . 'legacy_flags' . DS, $property->getValue($this->_controller));
 	}
 
 }


### PR DESCRIPTION
`DataHelper` reads the country flag image path from the camelCase key `Country.imagePath` (and `Language.imagePath`), but `CountriesController` and `Admin/CountriesController` read the snake_case `Country.image_path` in `beforeFilter()`. So the documented `Country.imagePath` was silently ignored by the controllers — the admin flag-management pages kept using the bundled path.

Both controllers now read the camelCase key first with the snake_case as a backward-compatible fallback: `Configure::read('Country.imagePath') ?? Configure::read('Country.image_path')`. This aligns the controllers with the helper and the documentation while not breaking anyone who currently sets `image_path`.

`config/app.example.php` is cleaned up to document only `imagePath` (the snake_case key is now an invisible BC fallback). Regression tests cover both the camelCase key and the BC fallback in each controller.
