### PR TITLE
Make composer stan-tests runnable without phpunit.phar

### DIFF
--- a/tests/TestCase/Model/Table/TimezonesTableTest.php
+++ b/tests/TestCase/Model/Table/TimezonesTableTest.php
@@ -34,15 +34,6 @@ class TimezonesTableTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function tearDown(): void {
-		unset($this->Timezones);
-
-		parent::tearDown();
-	}
-
-	/**
-	 * @return void
-	 */
 	public function testValidationDefault(): void {
 		$this->markTestIncomplete('Not implemented yet.');
 	}

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -4,5 +4,4 @@ parameters:
 		- TestCase/
 	bootstrapFiles:
 		- bootstrap.php
-		- ../phpunit.phar
 	ignoreErrors:


### PR DESCRIPTION
The `composer stan-tests` script (`phpstan analyze -c tests/phpstan.neon`) listed `../phpunit.phar` as a bootstrap file, but no `phpunit.phar` exists in a normal `composer install` setup — PHPUnit is pulled in as a dev dependency and is already available via `tests/bootstrap.php` (which requires `vendor/autoload.php`). As a result the script always aborted with "Bootstrap file `phpunit.phar` does not exist" and never actually analyzed the test suite. (CI does not run `stan-tests`, so this only affected local/contributor use.)

This removes the stale `../phpunit.phar` bootstrap entry. With the analysis now running, it surfaced one pre-existing error — `unset($this->Timezones)` in `TimezonesTableTest` (flagged under PHP 8.4 property hooks). That `tearDown` only unset a local reference (no other table test in the suite does this and the parent already handles cleanup), so it is removed. `composer stan-tests` now reports no errors.
