### PR TITLE
Default Addresses.foreign_id to int following unsigned_primary_keys

### DIFF
--- a/config/Migrations/20201014000224_MigrationAddresses.php
+++ b/config/Migrations/20201014000224_MigrationAddresses.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types = 1);
 
+use Cake\Core\Configure;
 use Migrations\BaseMigration;
 
 // phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
@@ -16,6 +17,13 @@ class MigrationAddresses extends BaseMigration {
 	 * @return void
 	 */
 	public function change() {
+		// The polymorphic foreign_id references a host record's primary key, so it
+		// must match the application's primary-key signedness. The flag is false
+		// (signed primary keys) when unset, so an unset flag yields a signed column,
+		// matching the default-signed ids it references. Pass the default explicitly
+		// to make that intent unmistakable. (Unsigned only takes effect on MySQL.)
+		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
+
 		$this->table('addresses')
 			->addColumn('id', 'integer', [
 				'autoIncrement' => true,
@@ -49,10 +57,10 @@ class MigrationAddresses extends BaseMigration {
 				'limit' => 80,
 				'null' => false,
 			])
-			->addColumn('foreign_id', 'string', [
+			->addColumn('foreign_id', 'biginteger', [
 				'default' => null,
-				'limit' => 10,
 				'null' => true,
+				'signed' => $signed,
 			])
 			->addColumn('model_key', 'string', [
 				'default' => '',

--- a/config/Migrations/20201014000224_MigrationAddresses.php
+++ b/config/Migrations/20201014000224_MigrationAddresses.php
@@ -17,12 +17,18 @@ class MigrationAddresses extends BaseMigration {
 	 * @return void
 	 */
 	public function change() {
-		// The polymorphic foreign_id references a host record's primary key, so it
-		// must match the application's primary-key signedness. The flag is false
-		// (signed primary keys) when unset, so an unset flag yields a signed column,
-		// matching the default-signed ids it references. Pass the default explicitly
-		// to make that intent unmistakable. (Unsigned only takes effect on MySQL.)
+		// The polymorphic foreign_id type and signedness follow the application's
+		// Polymorphic.type and Migrations.unsigned_primary_keys config keys.
+		$type = (string)Configure::read('Polymorphic.type', 'integer');
 		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
+
+		$polymorphicOptions = [
+			'default' => null,
+			'null' => true,
+		];
+		if (in_array($type, ['integer', 'biginteger'], true)) {
+			$polymorphicOptions['signed'] = $signed;
+		}
 
 		$this->table('addresses')
 			->addColumn('id', 'integer', [
@@ -57,11 +63,7 @@ class MigrationAddresses extends BaseMigration {
 				'limit' => 80,
 				'null' => false,
 			])
-			->addColumn('foreign_id', 'biginteger', [
-				'default' => null,
-				'null' => true,
-				'signed' => $signed,
-			])
+			->addColumn('foreign_id', $type, $polymorphicOptions)
 			->addColumn('model_key', 'string', [
 				'default' => '',
 				'limit' => 60,

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,22 +26,19 @@ It also contains:
 
 `Address` records attach to any host record via the polymorphic `foreign_id`
 (the host record's primary key) together with `model` (the host model name).
-`foreign_id` is a `biginteger` and follows the application's primary-key
-signedness via the `Migrations.unsigned_primary_keys` flag, so it lines up with
-the integer ids it references.
 
-### Using UUIDs
+`foreign_id` defaults to `integer` and its type is controlled by the global
+`Polymorphic.type` config key. Accepted values are `integer`, `biginteger`,
+`uuid`, and `binaryuuid`. For the integer variants the column signedness follows
+`Migrations.unsigned_primary_keys`. For UUID variants no signedness option is
+applied.
 
-If your host records use UUID primary keys, add a migration in your application
-that changes the column type after the plugin's tables exist:
+To use a different type, set the config before running migrations — for example
+in `config/app.php` or `config/app_local.php`:
 
 ```php
-$this->table('addresses')
-    ->changeColumn('foreign_id', 'uuid', [
-        'null' => true,
-        'default' => null,
-    ])
-    ->update();
+// In your app config (e.g. config/app.php or config/app_local.php):
+Configure::write('Polymorphic.type', 'uuid'); // or 'biginteger' / 'binaryuuid'
 ```
 
 ## Country Icons

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,9 +37,15 @@ To use a different type, set the config before running migrations — for exampl
 in `config/app.php` or `config/app_local.php`:
 
 ```php
-// In your app config (e.g. config/app.php or config/app_local.php):
-Configure::write('Polymorphic.type', 'uuid'); // or 'biginteger' / 'binaryuuid'
+// config/app.php (merged into Configure at bootstrap, including the migrations CLI)
+'Polymorphic' => [
+    'type' => 'uuid', // integer (default) | biginteger | uuid | binaryuuid
+],
 ```
+
+This setting only affects *fresh installs* (i.e. when the migration runs for the
+first time). Existing installs keep their current column type; to change the type
+on an existing install, write an app-level migration that alters the column.
 
 ## Country Icons
 The plugin ships with default icons in `webroot/img/country_flags/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,28 @@ It also contains:
 - Currencies
 - MimeTypes and MimeTypeImages
 
+## Addresses
+
+`Address` records attach to any host record via the polymorphic `foreign_id`
+(the host record's primary key) together with `model` (the host model name).
+`foreign_id` is a `biginteger` and follows the application's primary-key
+signedness via the `Migrations.unsigned_primary_keys` flag, so it lines up with
+the integer ids it references.
+
+### Using UUIDs
+
+If your host records use UUID primary keys, add a migration in your application
+that changes the column type after the plugin's tables exist:
+
+```php
+$this->table('addresses')
+    ->changeColumn('foreign_id', 'uuid', [
+        'null' => true,
+        'default' => null,
+    ])
+    ->update();
+```
+
 ## Country Icons
 The plugin ships with default icons in `webroot/img/country_flags/`.
 It is recommended to copy them to APP level, though, for performance reasons.

--- a/src/Model/Entity/Address.php
+++ b/src/Model/Entity/Address.php
@@ -6,6 +6,7 @@ use Tools\Model\Entity\Entity;
 
 /**
  * @property int $id
+ * @property int|null $foreign_id
  * @property int|null $category_id
  * @property int|null $address_type_id
  * @property int|null $location_id

--- a/tests/Fixture/AddressesFixture.php
+++ b/tests/Fixture/AddressesFixture.php
@@ -17,7 +17,7 @@ class AddressesFixture extends TestFixture {
 	 */
 	public array $fields = [
 		'id' => ['type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'collate' => null, 'comment' => ''],
-		'foreign_id' => ['type' => 'biginteger', 'null' => false, 'default' => null, 'length' => 20, 'unsigned' => false, 'comment' => ''],
+		'foreign_id' => ['type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'unsigned' => false, 'comment' => ''],
 		'model' => ['type' => 'string', 'null' => false, 'default' => null, 'length' => 30, 'comment' => '', 'charset' => 'utf8'],
 		'country_id' => ['type' => 'integer', 'null' => true, 'default' => null, 'length' => 10, 'collate' => null, 'comment' => 'redundance purposely'],
 		'first_name' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 50, 'comment' => '', 'charset' => 'utf8'],

--- a/tests/Fixture/AddressesFixture.php
+++ b/tests/Fixture/AddressesFixture.php
@@ -17,7 +17,7 @@ class AddressesFixture extends TestFixture {
 	 */
 	public array $fields = [
 		'id' => ['type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'collate' => null, 'comment' => ''],
-		'foreign_id' => ['type' => 'uuid', 'null' => false, 'default' => null, 'length' => 36, 'comment' => '', 'charset' => 'utf8'],
+		'foreign_id' => ['type' => 'biginteger', 'null' => false, 'default' => null, 'length' => 20, 'unsigned' => false, 'comment' => ''],
 		'model' => ['type' => 'string', 'null' => false, 'default' => null, 'length' => 30, 'comment' => '', 'charset' => 'utf8'],
 		'country_id' => ['type' => 'integer', 'null' => true, 'default' => null, 'length' => 10, 'collate' => null, 'comment' => 'redundance purposely'],
 		'first_name' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 50, 'comment' => '', 'charset' => 'utf8'],
@@ -43,7 +43,7 @@ class AddressesFixture extends TestFixture {
 	 */
 	public array $records = [
 		[
-			'foreign_id' => '481fc6d0-b920-43e0-a40d-111111111111',
+			'foreign_id' => 11,
 			'model' => 'Partner',
 			'country_id' => null,
 			'first_name' => 'Hans',
@@ -60,7 +60,7 @@ class AddressesFixture extends TestFixture {
 			'type_id' => '0',
 		],
 		[
-			'foreign_id' => '481fc6d0-b920-43e0-a40d-111111111111',
+			'foreign_id' => 11,
 			'model' => 'Restaurant',
 			'country_id' => '1',
 			'first_name' => '',
@@ -77,7 +77,7 @@ class AddressesFixture extends TestFixture {
 			'type_id' => '0',
 		],
 		[
-			'foreign_id' => '481fc6d0-b920-43e0-a40d-111111111111',
+			'foreign_id' => 11,
 			'model' => 'Partner',
 			'country_id' => null,
 			'first_name' => 'Tim',
@@ -94,7 +94,7 @@ class AddressesFixture extends TestFixture {
 			'type_id' => '0',
 		],
 		[
-			'foreign_id' => '481fc6d0-b920-43e0-a40d-111111111111',
+			'foreign_id' => 11,
 			'model' => 'Restaurant',
 			'country_id' => '1',
 			'first_name' => '',

--- a/tests/Fixture/AddressesFixture.php
+++ b/tests/Fixture/AddressesFixture.php
@@ -17,7 +17,7 @@ class AddressesFixture extends TestFixture {
 	 */
 	public array $fields = [
 		'id' => ['type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'collate' => null, 'comment' => ''],
-		'foreign_id' => ['type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'unsigned' => false, 'comment' => ''],
+		'foreign_id' => ['type' => 'integer', 'null' => true, 'default' => null, 'length' => 10, 'unsigned' => false, 'comment' => ''],
 		'model' => ['type' => 'string', 'null' => false, 'default' => null, 'length' => 30, 'comment' => '', 'charset' => 'utf8'],
 		'country_id' => ['type' => 'integer', 'null' => true, 'default' => null, 'length' => 10, 'collate' => null, 'comment' => 'redundance purposely'],
 		'first_name' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 50, 'comment' => '', 'charset' => 'utf8'],

--- a/tests/TestCase/Model/Table/AddressesTableTest.php
+++ b/tests/TestCase/Model/Table/AddressesTableTest.php
@@ -69,7 +69,7 @@ class AddressesTableTest extends TestCase {
 		$this->Addresses->addBehavior('Geocoder', ['className' => TestGeocoderBehavior::class]);
 
 		$data = [
-			'foreign_id' => 'eb25610d-7bfa-4e34-812c-ad72b100fb26',
+			'foreign_id' => 22,
 			'model' => 'Foo',
 			'city' => 'Berlin',
 		];
@@ -85,7 +85,7 @@ class AddressesTableTest extends TestCase {
 		$this->Addresses->removeBehavior('Geocoder');
 
 		$data = [
-			'foreign_id' => 'eb25610d-7bfa-4e34-812c-ad72b100fb26',
+			'foreign_id' => 22,
 			'model' => 'Foo',
 			'city' => 'Berlin',
 			'country_id' => 1,
@@ -103,7 +103,7 @@ class AddressesTableTest extends TestCase {
 		$this->Addresses->removeBehavior('Geocoder');
 
 		$data = [
-			'foreign_id' => 'eb25610d-7bfa-4e34-812c-ad72b100fb26',
+			'foreign_id' => 22,
 			'model' => 'Foo',
 			'city' => 'Berlin',
 			'country_id' => 1,


### PR DESCRIPTION
## Problem

`addresses.foreign_id` is a polymorphic reference (a host record's primary key, paired with `model`). It was declared as `string(10)` in the create migration while the fixture and test data used `uuid(36)` — contradictory, and a 10-character string cannot even hold a UUID.

## Fix

`foreign_id` now defaults to `integer` and follows a single global config key, `Polymorphic.type`, shared across the polymorphic-FK plugins:

```php
// config/app.php or config/app_local.php
Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
```

- For the integer variants (`integer` / `biginteger`), signedness follows `Migrations.unsigned_primary_keys` (signed when the flag is unset); `uuid` / `binaryuuid` set no signedness.
- Fixture and entity aligned to `integer`.
- Docs replace the old "copy the migration to use UUID" instructions with the config switch.

Editing the create migration sets the default for fresh installs; existing installs are unaffected (the create migration does not re-run). Type/signedness only take effect on MySQL for the integer variants.
