### PR TITLE
Fix addresses migration: duplicate postal_code column and missing last_used

### DIFF
--- a/config/Migrations/20201014000224_MigrationAddresses.php
+++ b/config/Migrations/20201014000224_MigrationAddresses.php
@@ -69,11 +69,6 @@ class MigrationAddresses extends BaseMigration {
 				'limit' => 60,
 				'null' => true,
 			])
-			->addColumn('postal_code', 'string', [
-				'default' => null,
-				'limit' => 7,
-				'null' => false,
-			])
 			->addColumn('formatted_address', 'string', [
 				'default' => null,
 				'limit' => 190,
@@ -84,6 +79,10 @@ class MigrationAddresses extends BaseMigration {
 				'null' => true,
 			])
 			->addColumn('lng', 'float', [
+				'default' => null,
+				'null' => true,
+			])
+			->addColumn('last_used', 'datetime', [
 				'default' => null,
 				'null' => true,
 			])

--- a/config/Migrations/20201014000224_MigrationAddresses.php
+++ b/config/Migrations/20201014000224_MigrationAddresses.php
@@ -84,6 +84,7 @@ class MigrationAddresses extends BaseMigration {
 			])
 			->addColumn('last_used', 'datetime', [
 				'default' => null,
+				'limit' => null,
 				'null' => true,
 			])
 			->addColumn('created', 'datetime', [


### PR DESCRIPTION
## Problem

The `addresses` create migration (`config/Migrations/20201014000224_MigrationAddresses.php`) has two bugs that slipped in with an earlier automated upgrade pass:

- `postal_code` is declared **twice** in the same table builder chain (once `limit 10`, once `limit 7`). Phinx fails creating a duplicate column, so the migration cannot run on a fresh install.
- The `last_used` column is **missing**, even though `AddressesTable::touch()` writes to it and the test fixture includes it.

## Fix

- Remove the stray duplicate `postal_code` (`limit 7`); keep the single `limit 10` definition (matching the fixture).
- Add the missing `last_used` (`datetime`, nullable).

Schema-only fix to the create migration so fresh installs run and match the table/fixture. No behavior change for the polymorphic column.
