### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/DataHelper.php
+++ b/src/View/Helper/DataHelper.php
@@ -17,7 +17,7 @@ use Shim\Filesystem\Folder;
 class DataHelper extends Helper {
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 

--- a/src/View/Helper/MimeTypeHelper.php
+++ b/src/View/Helper/MimeTypeHelper.php
@@ -17,7 +17,7 @@ if (!defined('FILE_CACHE')) {
 class MimeTypeHelper extends Helper {
 
 	/**
-	 * @var array<mixed>
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 


### PR DESCRIPTION
Updates helper/component annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test